### PR TITLE
Add LOAD_BALANCING_MODE to modify algorithm used

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | M3U_URL_1, M3U_URL_2, M3U_URL_X | Set M3U URLs as environment variables.                  |   N/A            |   Any valid M3U URLs                                             |
 | M3U_MAX_CONCURRENCY_1, M3U_MAX_CONCURRENCY_2, M3U_MAX_CONCURRENCY_X | Set max concurrency.                                 |  1             |   Any integer                                             |
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
+| LOAD_BALANCING_MODE                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
 | TZ                          | Set timezone                                           | Etc/UTC     | [TZ Identifiers](https://nodatime.org/TimeZones) |
 | SYNC_CRON                   | Set cron schedule expression of the background updates. | 0 0 * * *   |  Any valid cron expression    |
 | SYNC_ON_BOOT                | Set if an initial background syncing will be executed on boot | true    | true/false   |

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -35,7 +35,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 				if strings.TrimSpace(maxCon) == "" {
 					maxCon = "1"
 				}
-				log.Printf("Concurrency limit reached (%s): %s", maxCon, url.Content)
+				log.Printf("Concurrency limit reached for M3U_%d (max: %s): %s", url.M3UIndex, maxCon, url.Content)
 				continue // Skip this stream if concurrency limit reached
 			}
 
@@ -58,7 +58,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 				if strings.TrimSpace(maxCon) == "" {
 					maxCon = "1"
 				}
-				log.Printf("Concurrency limit reached (%s): %s", maxCon, url.Content)
+				log.Printf("Concurrency limit reached for M3U_%d (max: %s): %s", url.M3UIndex, maxCon, url.Content)
 				continue // Skip this stream if concurrency limit reached
 			}
 
@@ -197,7 +197,7 @@ func checkConcurrency(m3uIndex int) bool {
 		return false // Error occurred, treat as concurrency not reached
 	}
 
-	log.Printf("Current concurrent connections for M3U_%d: %d", m3uIndex, count)
+	log.Printf("Current number of connections for M3U_%d: %d", m3uIndex, count)
 	return count >= maxConcurrency
 }
 
@@ -216,5 +216,5 @@ func updateConcurrency(m3uIndex int, incr bool) {
 	if err != nil {
 		log.Printf("Error checking concurrency: %s\n", err.Error())
 	}
-	log.Printf("Current concurrent connections for M3U_%d: %d", m3uIndex, count)
+	log.Printf("Current number of connections for M3U_%d: %d", m3uIndex, count)
 }


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Sometimes, we don't want to use the brute force method of load balancing. This method fills up one M3U connection first before trying out different M3Us. Having an option to use round-robin load balancing would be a good feature to have.

## Choices

* Add a LOAD_BALANCING_MODE to prevent breaking changes for people who prefer the brute force method instead of just simply changing the algorithm.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.