### PR TITLE
Add BUFFER_MB functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | M3U_MAX_CONCURRENCY_1, M3U_MAX_CONCURRENCY_2, M3U_MAX_CONCURRENCY_X | Set max concurrency.                                 |  1             |   Any integer                                             |
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
 | LOAD_BALANCING_MODE                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
+| BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any integer |
 | TZ                          | Set timezone                                           | Etc/UTC     | [TZ Identifiers](https://nodatime.org/TimeZones) |
 | SYNC_CRON                   | Set cron schedule expression of the background updates. | 0 0 * * *   |  Any valid cron expression    |
 | SYNC_ON_BOOT                | Set if an initial background syncing will be executed on boot | true    | true/false   |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | M3U_MAX_CONCURRENCY_1, M3U_MAX_CONCURRENCY_2, M3U_MAX_CONCURRENCY_X | Set max concurrency.                                 |  1             |   Any integer                                             |
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
 | LOAD_BALANCING_MODE                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
-| BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any integer |
+| BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any positive integer |
 | TZ                          | Set timezone                                           | Etc/UTC     | [TZ Identifiers](https://nodatime.org/TimeZones) |
 | SYNC_CRON                   | Set cron schedule expression of the background updates. | 0 0 * * *   |  Any valid cron expression    |
 | SYNC_ON_BOOT                | Set if an initial background syncing will be executed on boot | true    | true/false   |

--- a/main_test.go
+++ b/main_test.go
@@ -28,6 +28,7 @@ func TestMP4Handler(t *testing.T) {
 	defer cancel()
 
 	os.Setenv("M3U_URL_1", "https://gist.githubusercontent.com/sonroyaalmerol/de1c90e8681af040924da5d15c7f530d/raw/06844df09e69ea278060252ca5aa8d767eb4543d/test-m3u.m3u")
+	os.Setenv("BUFFER_MB", "3")
 
 	updateSources(ctx)
 

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -168,9 +168,13 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 				log.Printf("Invalid BUFFER_MB value: %s\n", err.Error())
 				bufferMbInt = 0
 			}
+
+			if bufferMbInt < 0 {
+				log.Printf("Invalid BUFFER_MB value: negative integer is not allowed\n")
+			}
 		}
 
-		if bufferMbInt != 0 {
+		if bufferMbInt > 0 {
 			log.Printf("Buffer is set to %dmb.\n", bufferMbInt)
 			buffer := make([]byte, 1024*bufferMbInt)
 			for {

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -159,13 +159,45 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		}()
 
 		updateConcurrency(selectedUrl.M3UIndex, true)
-		_, err := io.Copy(w, resp.Body)
-		if err != nil {
-			// Log the error
-			if errors.Is(err, syscall.EPIPE) {
-				log.Println("Client disconnected after fetching MP4 stream")
-			} else {
-				log.Printf("Error copying MP4 stream to response: %s\n", err.Error())
+
+		bufferMbInt := 0
+		bufferMb := os.Getenv("BUFFER_MB")
+		if bufferMb != "" {
+			bufferMbInt, err = strconv.Atoi(bufferMb)
+			if err != nil {
+				log.Printf("Invalid BUFFER_MB value: %s\n", err.Error())
+				bufferMbInt = 0
+			}
+		}
+
+		if bufferMbInt != 0 {
+			log.Printf("Buffer is set to %dmb.\n", bufferMbInt)
+			buffer := make([]byte, 1024*bufferMbInt)
+			for {
+				n, err := resp.Body.Read(buffer)
+				if err != nil {
+					if err != io.EOF {
+						log.Printf("Error reading MP4 stream: %s\n", err.Error())
+					}
+					break
+				}
+				if n > 0 {
+					_, err := w.Write(buffer[:n])
+					if err != nil {
+						log.Printf("Error writing to response: %s\n", err.Error())
+						break
+					}
+				}
+			}
+		} else {
+			_, err := io.Copy(w, resp.Body)
+			if err != nil {
+				// Log the error
+				if errors.Is(err, syscall.EPIPE) {
+					log.Println("Client disconnected after fetching MP4 stream")
+				} else {
+					log.Printf("Error copying MP4 stream to response: %s\n", err.Error())
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Intermittent connections do not resolve correctly as a "disconnect" state.

## Choices

* Add a functionality to use a buffer when streaming.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.