### PR TITLE
Optimize HTTP timeout

### DIFF
--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -8,12 +8,25 @@ import (
 	"log"
 	"m3u-stream-merger/database"
 	"m3u-stream-merger/utils"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
+
+var netTransport = &http.Transport{
+	Dial: (&net.Dialer{
+		Timeout: 5 * time.Second,
+	}).Dial,
+	TLSHandshakeTimeout: 5 * time.Second,
+}
+var httpClient = &http.Client{
+	Timeout:   time.Second * 10,
+	Transport: netTransport,
+}
 
 func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl *database.StreamURL, err error) {
 	loadBalancingMode := os.Getenv("LOAD_BALANCING_MODE")

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -17,18 +17,18 @@ import (
 	"time"
 )
 
-var netTransport = &http.Transport{
-	Dial: (&net.Dialer{
-		Timeout: 5 * time.Second,
-	}).Dial,
-	TLSHandshakeTimeout: 5 * time.Second,
-}
-var httpClient = &http.Client{
-	Timeout:   time.Second * 10,
-	Transport: netTransport,
-}
-
 func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl *database.StreamURL, err error) {
+	var netTransport = &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 5 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 5 * time.Second,
+	}
+	var httpClient = &http.Client{
+		Timeout:   time.Second * 10,
+		Transport: netTransport,
+	}
+
 	loadBalancingMode := os.Getenv("LOAD_BALANCING_MODE")
 	if loadBalancingMode == "" {
 		loadBalancingMode = "brute-force"
@@ -52,7 +52,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 				continue // Skip this stream if concurrency limit reached
 			}
 
-			resp, err = http.Get(url.Content)
+			resp, err = httpClient.Get(url.Content)
 			if err == nil {
 				selectedUrl = &url
 				break
@@ -75,7 +75,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 				continue // Skip this stream if concurrency limit reached
 			}
 
-			resp, err = http.Get(url.Content)
+			resp, err = httpClient.Get(url.Content)
 			if err == nil {
 				selectedUrl = &url
 				break
@@ -92,7 +92,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 		log.Printf("All concurrency limits have been reached. Falling back to connection checking mode...\n")
 		// Connection check mode
 		for _, url := range stream.URLs {
-			resp, err = http.Get(url.Content)
+			resp, err = httpClient.Get(url.Content)
 			if err == nil {
 				selectedUrl = &url
 				break

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -18,13 +18,13 @@ import (
 )
 
 func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl *database.StreamURL, err error) {
-	var netTransport = &http.Transport{
+	netTransport := &http.Transport{
 		Dial: (&net.Dialer{
 			Timeout: 5 * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout: 5 * time.Second,
 	}
-	var httpClient = &http.Client{
+	httpClient := &http.Client{
 		Timeout:   time.Second * 10,
 		Transport: netTransport,
 	}


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Go’s http package doesn’t specify request timeouts by default, allowing a possibility of services hijacking goroutines.

## Choices

* Cap the TCP connect and TLS handshake timeouts, as well as establishing an end-to-end request timeout.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.