### PR TITLE
correct data path and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./data:/app/data # OPTIONAL: only if you want the M3U generated to persist across restarts
+      - ./data:/data # OPTIONAL: only if you want the M3U generated to persist across restarts
     environment:
       - TZ=America/Toronto
-      - SYNC_ON_B0OT=true
+      - SYNC_ON_BOOT=true
       - SYNC_CRON=0 0 * * *
       - M3U_URL_1=https://iptvprovider1.com/playlist.m3u
       - M3U_MAX_CONCURRENCY_1=2


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Corrected path for data persistent in docker-compose example and fix typo for SYNC_ON_BOOT in readme file.

## Choices

* N/A

## Test instructions

1. N/A

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.