### PR TITLE
Groups include filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
 | LOAD_BALANCING_MODE                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
 | BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any positive integer |
+| INCLUDE_GROUPS                | Set channel groups to include | all    | Comma-separated values   |
 | TZ                          | Set timezone                                           | Etc/UTC     | [TZ Identifiers](https://nodatime.org/TimeZones) |
 | SYNC_CRON                   | Set cron schedule expression of the background updates. | 0 0 * * *   |  Any valid cron expression    |
 | SYNC_ON_BOOT                | Set if an initial background syncing will be executed on boot | true    | true/false   |

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -119,9 +119,7 @@ func insertStreamToDb(db *sql.DB, currentStream database.StreamInfo) error {
 	return nil
 }
 
-// Should group be included
 func checkInludeGroup(groups []string, line string) bool {
-
 	if len(groups) == 0 {
 		return true
 	} else {

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -123,8 +123,8 @@ func checkIncludeGroup(groups []string, line string) bool {
 		return true
 	} else {
 		for _, group := range groups {
-			toMatch := strings.ToLower("group-title=" + "\"" + group + "\"")
-			if strings.Contains(strings.ToLower(line), toMatch) {
+			toMatch := "group-title=" + "\"" + group + "\""
+			if strings.Contains(line, toMatch) {
 				return true
 			}
 		}

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -118,7 +118,7 @@ func insertStreamToDb(db *database.Instance, currentStream database.StreamInfo) 
 	return nil
 }
 
-func checkInludeGroup(groups []string, line string) bool {
+func checkIncludeGroup(groups []string, line string) bool {
 	if len(groups) == 0 {
 		return true
 	} else {
@@ -186,7 +186,7 @@ func ParseM3UFromURL(db *database.Instance, m3uURL string, m3uIndex int) error {
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			if strings.HasPrefix(line, "#EXTINF:") && checkInludeGroup(grps, line) {
+			if strings.HasPrefix(line, "#EXTINF:") && checkIncludeGroup(grps, line) {
 				if scanner.Scan() {
 					wg.Add(2)
 					nextLine := scanner.Text()

--- a/main_test.go
+++ b/main_test.go
@@ -29,6 +29,7 @@ func TestMP4Handler(t *testing.T) {
 
 	os.Setenv("M3U_URL_1", "https://gist.githubusercontent.com/sonroyaalmerol/de1c90e8681af040924da5d15c7f530d/raw/06844df09e69ea278060252ca5aa8d767eb4543d/test-m3u.m3u")
 	os.Setenv("BUFFER_MB", "3")
+	os.Setenv("INCLUDE_GROUPS", "movies")
 
 	updateSources(ctx)
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Include only selected channel groups to parse. Often lots of unwanted groups in playlist, taking time to parse.

## Choices

* Just checking during parsing if channel groups should be included or not, default is all.

## Test instructions

1. Test run on several huge playlists.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.