### PR TITLE
Optimize database instances

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -36,12 +38,12 @@ func TestSaveAndLoadFromSQLite(t *testing.T) {
 		}},
 	}}
 
-	err = SaveToSQLite(db, expected) // Insert test data into the database
+	err = db.SaveToSQLite(expected) // Insert test data into the database
 	if err != nil {
 		t.Errorf("SaveToSQLite returned error: %v", err)
 	}
 
-	result, err := GetStreams(db)
+	result, err := db.GetStreams()
 	if err != nil {
 		t.Errorf("GetStreams returned error: %v", err)
 	}
@@ -56,17 +58,17 @@ func TestSaveAndLoadFromSQLite(t *testing.T) {
 		}
 	}
 
-	err = DeleteStreamByTitle(db, expected[1].Title)
+	err = db.DeleteStreamByTitle(expected[1].Title)
 	if err != nil {
 		t.Errorf("DeleteStreamByTitle returned error: %v", err)
 	}
 
-	err = DeleteStreamURL(db, expected[0].URLs[0].DbId)
+	err = db.DeleteStreamURL(expected[0].URLs[0].DbId)
 	if err != nil {
 		t.Errorf("DeleteStreamURL returned error: %v", err)
 	}
 
-	result, err = GetStreams(db)
+	result, err = db.GetStreams()
 	if err != nil {
 		t.Errorf("GetStreams returned error: %v", err)
 	}
@@ -84,9 +86,15 @@ func TestSaveAndLoadFromSQLite(t *testing.T) {
 		}
 	}
 
-	err = DeleteSQLite("test")
+	err = db.DeleteSQLite()
 	if err != nil {
 		t.Errorf("DeleteSQLite returned error: %v", err)
+	}
+
+	foldername := filepath.Join(".", "data")
+	err = os.RemoveAll(foldername)
+	if err != nil {
+		t.Errorf("Error deleting data folder: %v\n", err)
 	}
 }
 

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -1,7 +1,6 @@
 package m3u
 
 import (
-	"database/sql"
 	"fmt"
 	"log"
 	"m3u-stream-merger/database"
@@ -13,8 +12,8 @@ func generateStreamURL(baseUrl string, title string) string {
 	return fmt.Sprintf("%s/%s.mp4\n", baseUrl, utils.GetStreamUID(title))
 }
 
-func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *sql.DB) {
-	streams, err := database.GetStreams(db)
+func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Instance) {
+	streams, err := db.GetStreams()
 	if err != nil {
 		log.Println(fmt.Errorf("GetStreams error: %v", err))
 	}

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"m3u-stream-merger/database"
@@ -25,7 +27,7 @@ func TestGenerateM3UContent(t *testing.T) {
 		t.Errorf("InitializeSQLite returned error: %v", err)
 	}
 
-	_, err = database.InsertStream(db, stream)
+	_, err = db.InsertStream(stream)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,9 +69,15 @@ func TestGenerateM3UContent(t *testing.T) {
 			rr.Body.String(), expectedContent)
 	}
 
-	err = database.DeleteSQLite("test")
+	err = db.DeleteSQLite()
 	if err != nil {
 		t.Errorf("DeleteSQLite returned error: %v", err)
+	}
+
+	foldername := filepath.Join(".", "data")
+	err = os.RemoveAll(foldername)
+	if err != nil {
+		t.Errorf("Error deleting data folder: %v\n", err)
 	}
 }
 
@@ -129,7 +137,7 @@ http://example.com/fox
 		}},
 	}
 
-	storedStreams, err := database.GetStreams(db)
+	storedStreams, err := db.GetStreams()
 	if err != nil {
 		t.Fatalf("Error retrieving streams from database: %v", err)
 	}
@@ -157,9 +165,15 @@ http://example.com/fox
 		}
 	}
 
-	err = database.DeleteSQLite("test")
+	err = db.DeleteSQLite()
 	if err != nil {
 		t.Errorf("DeleteSQLite returned error: %v", err)
+	}
+
+	foldername := filepath.Join(".", "data")
+	err = os.RemoveAll(foldername)
+	if err != nil {
+		t.Errorf("Error deleting data folder: %v\n", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ func swapDb(newInstance *database.Instance) error {
 		if err != nil {
 			return fmt.Errorf("Error renaming next_streams to current_streams: %v\n", err)
 		}
+
+		db = newInstance
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"m3u-stream-merger/database"
@@ -16,56 +15,49 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-var db *sql.DB
+var db *database.Instance
 var cronMutex sync.Mutex
+var swappingLock sync.Mutex
 
-func swapDb() error {
-	// Generate a unique temporary name
+func swapDb(newInstance *database.Instance) error {
+	swappingLock.Lock()
+	defer swappingLock.Unlock()
+
+	if db == nil {
+		err := newInstance.RenameSQLite("current_streams")
+		if err != nil {
+			return fmt.Errorf("Error renaming next_streams to current_streams: %v\n", err)
+		}
+		return nil
+	}
+
 	tempName := fmt.Sprintf("temp_%d", time.Now().UnixNano())
 
-	// Rename the current database to a temporary name
-	err := database.RenameSQLite("current_streams", tempName)
+	err := db.RenameSQLite(tempName)
 	if err != nil {
 		return fmt.Errorf("Error renaming current_streams to temp: %v\n", err)
 	}
 
-	// Rename the next database to current
-	err = database.RenameSQLite("next_streams", "current_streams")
+	err = newInstance.RenameSQLite("current_streams")
 	if err != nil {
-		// If renaming fails, revert the previous renaming to maintain consistency
-		revertErr := database.RenameSQLite(tempName, "current_streams")
+		revertErr := db.RenameSQLite("current_streams")
 		if revertErr != nil {
 			return fmt.Errorf("Error renaming back to current_streams: %v\n", revertErr)
 		}
 		return fmt.Errorf("Error renaming next_streams to current_streams: %v\n", err)
 	}
 
-	// Initialize the new current database
-	db, err = database.InitializeSQLite("current_streams")
+	err = db.DeleteSQLite()
 	if err != nil {
-		// If initialization fails, revert both renamings
-		revertErr := database.RenameSQLite(tempName, "current_streams")
-		if revertErr != nil {
-			return fmt.Errorf("Error renaming back to current_streams: %v\n", revertErr)
-		}
-		revertErr = database.RenameSQLite("current_streams", "next_streams")
-		if revertErr != nil {
-			return fmt.Errorf("Error renaming back to next_streams: %v\n", revertErr)
-		}
-		return fmt.Errorf("Error initializing current_streams: %v\n", err)
-	}
-
-	// Delete the temporary database
-	err = database.DeleteSQLite(tempName)
-	if err != nil {
-		// Log the error but do not return as this is not a critical error
 		fmt.Printf("Error deleting temp database: %v\n", err)
 	}
+
+	db = newInstance
 
 	return nil
 }
 
-func updateSource(nextDb *sql.DB, m3uUrl string, index int) {
+func updateSource(nextDb *database.Instance, m3uUrl string, index int) {
 	log.Printf("Background process: Updating M3U #%d from %s\n", index, m3uUrl)
 	err := m3u.ParseM3UFromURL(nextDb, m3uUrl, index)
 	if err != nil {
@@ -102,7 +94,7 @@ func updateSources(ctx context.Context) {
 			log.Printf("Background process: Fetching M3U_URL_%d...\n", index)
 			wg.Add(1)
 			// Start the goroutine for periodic updates
-			go func(nextDb *sql.DB, m3uUrl string, index int) {
+			go func(nextDb *database.Instance, m3uUrl string, index int) {
 				defer wg.Done()
 				updateSource(nextDb, m3uUrl, index)
 			}(nextDb, m3uUrl, index)
@@ -111,7 +103,7 @@ func updateSources(ctx context.Context) {
 		}
 		wg.Wait()
 
-		err = swapDb()
+		err = swapDb(nextDb)
 		if err != nil {
 			log.Fatalf("swapDb: %v", err)
 		}
@@ -171,6 +163,9 @@ func main() {
 
 	// HTTP handlers
 	http.HandleFunc("/playlist.m3u", func(w http.ResponseWriter, r *http.Request) {
+		swappingLock.Lock()
+		defer swappingLock.Unlock()
+
 		m3u.GenerateM3UContent(w, r, db)
 	})
 	http.HandleFunc("/stream/", func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ func swapDb(newInstance *database.Instance) error {
 		}
 
 		db = newInstance
+		newInstance = nil
+
 		return nil
 	}
 
@@ -55,6 +57,7 @@ func swapDb(newInstance *database.Instance) error {
 	}
 
 	db = newInstance
+	newInstance = nil
 
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 )
@@ -32,7 +33,7 @@ func TestMP4Handler(t *testing.T) {
 
 	updateSources(ctx)
 
-	streams, err := database.GetStreams(db)
+	streams, err := db.GetStreams()
 	if err != nil {
 		t.Errorf("GetStreams returned error: %v", err)
 	}
@@ -72,8 +73,14 @@ func TestMP4Handler(t *testing.T) {
 
 	wg.Wait()
 
-	err = database.DeleteSQLite("current_streams")
+	err = db.DeleteSQLite()
 	if err != nil {
 		t.Errorf("DeleteSQLite returned error: %v", err)
+	}
+
+	foldername := filepath.Join(".", "data")
+	err = os.RemoveAll(foldername)
+	if err != nil {
+		t.Errorf("Error deleting data folder: %v\n", err)
 	}
 }

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -100,7 +99,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 	return resp, selectedUrl, nil
 }
 
-func mp4Handler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
+func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	ctx := r.Context()
 
 	// Log the incoming request
@@ -119,7 +118,7 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 		return
 	}
 
-	stream, err := database.GetStreamByTitle(db, streamName)
+	stream, err := db.GetStreamByTitle(streamName)
 	if err != nil {
 		http.NotFound(w, r)
 		return


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* The current handling of databases can be a lot cleaner if each instance/connection will have its own mutex state.

## Choices

* Create a separate struct for each database instance with separate mutex.
* Add a global `swappingLock` to make sure the playlist route will wait until database swap is finished.
* Add playlist route HTTP status test. 

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.