### PR TITLE
Enable SQLite WAL mode and remove read locks

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -41,6 +41,11 @@ func InitializeSQLite(name string) (db *Instance, err error) {
 		return nil, fmt.Errorf("error opening SQLite database: %v\n", err)
 	}
 
+	_, err = db.Sql.Exec("PRAGMA journal_mode=WAL;")
+	if err != nil {
+		return nil, fmt.Errorf("error enabling wal mode: %v\n", err)
+	}
+
 	// Create table if not exists
 	_, err = db.Sql.Exec(`
 		CREATE TABLE IF NOT EXISTS streams (
@@ -306,9 +311,6 @@ func (db *Instance) DeleteStreamURL(streamURLID int64) error {
 }
 
 func (db *Instance) GetStreamByTitle(title string) (s StreamInfo, err error) {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
-
 	rows, err := db.Sql.Query("SELECT id, title, tvg_id, logo_url, group_name FROM streams WHERE title = ?", title)
 	if err != nil {
 		return s, fmt.Errorf("error querying streams: %v", err)
@@ -354,9 +356,6 @@ func (db *Instance) GetStreamByTitle(title string) (s StreamInfo, err error) {
 }
 
 func (db *Instance) GetStreamUrlByUrlAndIndex(url string, m3u_index int) (s StreamURL, err error) {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
-
 	rows, err := db.Sql.Query("SELECT id, content, m3u_index FROM stream_urls WHERE content = ? AND m3u_index = ? ORDER BY m3u_index ASC", url, m3u_index)
 	if err != nil {
 		return s, fmt.Errorf("error querying streams: %v", err)
@@ -378,9 +377,6 @@ func (db *Instance) GetStreamUrlByUrlAndIndex(url string, m3u_index int) (s Stre
 }
 
 func (db *Instance) GetStreams() ([]StreamInfo, error) {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
-
 	rows, err := db.Sql.Query("SELECT id, title, tvg_id, logo_url, group_name FROM streams")
 	if err != nil {
 		return nil, fmt.Errorf("error querying streams: %v", err)

--- a/database/db.go
+++ b/database/db.go
@@ -11,16 +11,19 @@ import (
 )
 
 type Instance struct {
-	Sql      *sql.DB
-	FileName string
-	Lock     sync.Mutex
+	Sql       *sql.DB
+	FileName  string
+	FileLock  sync.Mutex
+	WriteLock sync.Mutex
 }
 
 func InitializeSQLite(name string) (db *Instance, err error) {
 	db = new(Instance)
 
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
+	db.FileLock.Lock()
+	db.WriteLock.Lock()
+	defer db.FileLock.Unlock()
+	defer db.WriteLock.Unlock()
 
 	foldername := filepath.Join(".", "data")
 	db.FileName = filepath.Join(foldername, fmt.Sprintf("%s.db", name))
@@ -78,8 +81,10 @@ func InitializeSQLite(name string) (db *Instance, err error) {
 
 // DeleteSQLite deletes the SQLite database file.
 func (db *Instance) DeleteSQLite() error {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
+	db.FileLock.Lock()
+	db.WriteLock.Lock()
+	defer db.FileLock.Unlock()
+	defer db.WriteLock.Unlock()
 
 	_ = db.Sql.Close()
 
@@ -94,8 +99,10 @@ func (db *Instance) DeleteSQLite() error {
 }
 
 func (db *Instance) RenameSQLite(newName string) error {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
+	db.FileLock.Lock()
+	db.WriteLock.Lock()
+	defer db.FileLock.Unlock()
+	defer db.WriteLock.Unlock()
 
 	_ = db.Sql.Close()
 
@@ -117,8 +124,8 @@ func (db *Instance) RenameSQLite(newName string) error {
 }
 
 func (db *Instance) SaveToSQLite(streams []StreamInfo) (err error) {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
+	db.WriteLock.Lock()
+	defer db.WriteLock.Unlock()
 
 	tx, err := db.Sql.Begin()
 	if err != nil {
@@ -170,8 +177,8 @@ func (db *Instance) SaveToSQLite(streams []StreamInfo) (err error) {
 }
 
 func (db *Instance) InsertStream(s StreamInfo) (i int64, err error) {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
+	db.WriteLock.Lock()
+	defer db.WriteLock.Unlock()
 
 	tx, err := db.Sql.Begin()
 	if err != nil {
@@ -207,8 +214,8 @@ func (db *Instance) InsertStream(s StreamInfo) (i int64, err error) {
 }
 
 func (db *Instance) InsertStreamUrl(id int64, url StreamURL) (i int64, err error) {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
+	db.WriteLock.Lock()
+	defer db.WriteLock.Unlock()
 
 	tx, err := db.Sql.Begin()
 	if err != nil {
@@ -245,8 +252,8 @@ func (db *Instance) InsertStreamUrl(id int64, url StreamURL) (i int64, err error
 }
 
 func (db *Instance) DeleteStreamByTitle(title string) error {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
+	db.WriteLock.Lock()
+	defer db.WriteLock.Unlock()
 
 	tx, err := db.Sql.Begin()
 	if err != nil {
@@ -278,8 +285,8 @@ func (db *Instance) DeleteStreamByTitle(title string) error {
 }
 
 func (db *Instance) DeleteStreamURL(streamURLID int64) error {
-	db.Lock.Lock()
-	defer db.Lock.Unlock()
+	db.WriteLock.Lock()
+	defer db.WriteLock.Unlock()
 
 	tx, err := db.Sql.Begin()
 	if err != nil {


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* An SQLite database connection defaults to journal_mode=DELETE.
* WAL is significantly faster in most scenarios.
* WAL provides more concurrency as readers do not block writers and a writer does not block readers. Reading and writing can proceed concurrently.

## Choices

* Simply set `journal_mode` to WAL
* Separate file locks and write locks. Read locks are unnecessary as WAL mode can handle concurrent readers.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.