### PR TITLE
Relax the synchronization mode

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -49,6 +49,16 @@ func InitializeSQLite(name string) (db *Instance, err error) {
 		return nil, fmt.Errorf("error enabling wal mode: %v\n", err)
 	}
 
+	_, err = db.Sql.Exec("PRAGMA synchronous=normal;")
+	if err != nil {
+		return nil, fmt.Errorf("error enabling wal mode: %v\n", err)
+	}
+
+	_, err = db.Sql.Exec("PRAGMA journal_size_limit=6144000;")
+	if err != nil {
+		return nil, fmt.Errorf("error enabling wal mode: %v\n", err)
+	}
+
 	// Create table if not exists
 	_, err = db.Sql.Exec(`
 		CREATE TABLE IF NOT EXISTS streams (


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* The default for `synchronous` is full, which means every single update has to wait for `fsync`.
* The default of -1 for `journal_size_limit` means that there is no limit, so this disk file will grow in size indefinitely. This is not what we want.

## Choices

* Switch to normal synchronization. Normal is still completely corruption safe in WAL mode, and means only WAL checkpoints have to wait for `fsync`.
* Set `journal_size_limit` to a reasonable amount. The more data is in the journal file, the faster SQLite will be (generally). However, we also don’t want it to be too big, as this can start to negatively impact read performance.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.