### PR TITLE
add char filter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | LOAD_BALANCING_MODE                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
 | BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any positive integer |
 | INCLUDE_GROUPS                | Set channel groups to include | all    | Comma-separated values   |
+| CHARACTER_FILTER       | Filter unwanted chars in channel name | none    | Go regexp   |
 | TZ                          | Set timezone                                           | Etc/UTC     | [TZ Identifiers](https://nodatime.org/TimeZones) |
 | SYNC_CRON                   | Set cron schedule expression of the background updates. | 0 0 * * *   |  Any valid cron expression    |
 | SYNC_ON_BOOT                | Set if an initial background syncing will be executed on boot | true    | true/false   |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | LOAD_BALANCING_MODE                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
 | BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any positive integer |
 | INCLUDE_GROUPS                | Set channel groups to include | all    | Comma-separated values   |
-| CHARACTER_FILTER       | Filter unwanted chars in channel name | none    | Go regexp   |
+| TITLE_SUBSTR_FILTER | Sets a regex pattern used to exclude substrings from channel titles | none    | Go regexp   |
 | TZ                          | Set timezone                                           | Etc/UTC     | [TZ Identifiers](https://nodatime.org/TimeZones) |
 | SYNC_CRON                   | Set cron schedule expression of the background updates. | 0 0 * * *   |  Any valid cron expression    |
 | SYNC_ON_BOOT                | Set if an initial background syncing will be executed on boot | true    | true/false   |

--- a/m3u/middlewares.go
+++ b/m3u/middlewares.go
@@ -1,0 +1,43 @@
+package m3u
+
+import (
+	"log"
+	"os"
+	"regexp"
+	"strings"
+)
+
+func generalParser(value string) string {
+	if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+		value = strings.Trim(value, `"`)
+	}
+
+	return value
+}
+
+func tvgNameParser(value string) string {
+	substrFilter := os.Getenv("TITLE_SUBSTR_FILTER")
+	// Apply character filter
+	if substrFilter != "" {
+		re, err := regexp.Compile(substrFilter)
+		if err != nil {
+			log.Println("Error compiling character filter regex:", err)
+		} else {
+			value = re.ReplaceAllString(value, "")
+		}
+	}
+
+	return generalParser(value)
+}
+
+func tvgIdParser(value string) string {
+	return generalParser(value)
+}
+
+func groupTitleParser(value string) string {
+	return generalParser(value)
+}
+
+func tvgLogoParser(value string) string {
+	return generalParser(value)
+}

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -36,19 +36,15 @@ func parseLine(line string, nextLine string, m3uIndex int) database.StreamInfo {
 		key := strings.TrimSpace(match[1])
 		value := strings.TrimSpace(match[2])
 
-		if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
-			value = strings.Trim(value, `"`)
-		}
-
 		switch strings.ToLower(key) {
 		case "tvg-id":
-			currentStream.TvgID = value
+			currentStream.TvgID = tvgIdParser(value)
 		case "tvg-name":
-			currentStream.Title = value
+			currentStream.Title = tvgNameParser(value)
 		case "group-title":
-			currentStream.Group = value
+			currentStream.Group = groupTitleParser(value)
 		case "tvg-logo":
-			currentStream.LogoURL = value
+			currentStream.LogoURL = tvgLogoParser(value)
 		default:
 			if os.Getenv("DEBUG") == "true" {
 				log.Printf("Uncaught attribute: %s=%s\n", key, value)
@@ -168,8 +164,6 @@ func ParseM3UFromURL(db *database.Instance, m3uURL string, m3uIndex int) error {
 		grps = strings.Split(includeGroups, ",")
 	}
 
-	characterFilter := os.Getenv("CHARACTER_FILTER")
-
 	for i := 0; i <= maxRetries; i++ {
 		err := downloadM3UToBuffer(m3uURL, &buffer)
 		if err != nil {
@@ -189,18 +183,6 @@ func ParseM3UFromURL(db *database.Instance, m3uURL string, m3uIndex int) error {
 			line := scanner.Text()
 
 			if strings.HasPrefix(line, "#EXTINF:") && checkIncludeGroup(grps, line) {
-
-				// Apply character filter
-				if characterFilter != "" {
-					re, err := regexp.Compile(characterFilter)
-					if err != nil {
-						fmt.Println("Error compiling character filter regex:", err)
-					} else {
-						line = re.ReplaceAllString(line, "")
-					}
-
-				}
-
 				if scanner.Scan() {
 					wg.Add(2)
 					nextLine := scanner.Text()

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -168,6 +168,8 @@ func ParseM3UFromURL(db *database.Instance, m3uURL string, m3uIndex int) error {
 		grps = strings.Split(includeGroups, ",")
 	}
 
+	characterFilter := os.Getenv("CHARACTER_FILTER")
+
 	for i := 0; i <= maxRetries; i++ {
 		err := downloadM3UToBuffer(m3uURL, &buffer)
 		if err != nil {
@@ -187,6 +189,18 @@ func ParseM3UFromURL(db *database.Instance, m3uURL string, m3uIndex int) error {
 			line := scanner.Text()
 
 			if strings.HasPrefix(line, "#EXTINF:") && checkIncludeGroup(grps, line) {
+
+				// Apply character filter
+				if characterFilter != "" {
+					re, err := regexp.Compile(characterFilter)
+					if err != nil {
+						fmt.Println("Error compiling character filter regex:", err)
+					} else {
+						line = re.ReplaceAllString(line, "")
+					}
+
+				}
+
 				if scanner.Scan() {
 					wg.Add(2)
 					nextLine := scanner.Text()

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -65,7 +65,7 @@ func parseLine(line string, nextLine string, m3uIndex int) database.StreamInfo {
 	lineCommaSplit := strings.SplitN(lineWithoutPairs, ",", 2)
 
 	if len(lineCommaSplit) > 1 {
-		currentStream.Title = strings.TrimSpace(lineCommaSplit[1])
+		currentStream.Title = tvgNameParser(strings.TrimSpace(lineCommaSplit[1]))
 	}
 
 	return currentStream


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Some providers add country codes and other characters to channel names, this makes it possible to make them cleaner.

## Choices

* Apply go regexp makes it easy to filter unwanted chars.

## Test instructions

1. Tested different regexp on playlists.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.