### PR TITLE
Add timeout and use HTTP context with cancel

### DIFF
--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"io"
 	"log"
 	"m3u-stream-merger/database"
 	"m3u-stream-merger/utils"
@@ -11,7 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
+	"time"
 )
 
 func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl *database.StreamURL, err error) {
@@ -100,7 +99,8 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 }
 
 func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
-	ctx := r.Context()
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
 
 	// Log the incoming request
 	log.Printf("Received request from %s for URL: %s\n", r.RemoteAddr, r.URL.Path)
@@ -149,12 +149,19 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	// Log the successful response
 	log.Printf("Sent MP4 stream to %s\n", r.RemoteAddr)
 
-	// Use a channel for goroutine synchronization
-	done := make(chan struct{})
+	// Set initial timer duration
+	timerDuration := 5 * time.Second
+	timer := time.NewTimer(timerDuration)
+
+	// Function to reset the timer
+	resetTimer := func() {
+		timer.Reset(timerDuration)
+	}
+
 	go func() {
 		defer func() {
 			log.Printf("Closed connection for %s\n", r.RemoteAddr)
-			close(done)
+			cancel()
 		}()
 
 		updateConcurrency(selectedUrl.M3UIndex, true)
@@ -173,46 +180,45 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 			}
 		}
 
+		buffer := make([]byte, 512)
 		if bufferMbInt > 0 {
 			log.Printf("Buffer is set to %dmb.\n", bufferMbInt)
-			buffer := make([]byte, 1024*bufferMbInt)
-			for {
-				n, err := resp.Body.Read(buffer)
-				if err != nil {
-					if err != io.EOF {
-						log.Printf("Error reading MP4 stream: %s\n", err.Error())
-					}
-					break
-				}
-				if n > 0 {
-					_, err := w.Write(buffer[:n])
-					if err != nil {
-						log.Printf("Error writing to response: %s\n", err.Error())
-						break
-					}
-				}
-			}
-		} else {
-			_, err := io.Copy(w, resp.Body)
+			buffer = make([]byte, 1024*bufferMbInt)
+		}
+		for {
+			n, err := resp.Body.Read(buffer)
 			if err != nil {
-				// Log the error
-				if errors.Is(err, syscall.EPIPE) {
-					log.Println("Client disconnected after fetching MP4 stream")
-				} else {
-					log.Printf("Error copying MP4 stream to response: %s\n", err.Error())
+				log.Printf("Error reading MP4 stream: %s\n", err.Error())
+				cancel()
+			}
+			if n > 0 {
+				resetTimer()
+				_, err := w.Write(buffer[:n])
+				if err != nil {
+					log.Printf("Error writing to response: %s\n", err.Error())
+					cancel()
 				}
 			}
+		}
+	}()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			log.Println("Timeout reached, closing connection.")
+			cancel()
 		}
 	}()
 
 	// Wait for the request context to be canceled or the stream to finish
 	select {
 	case <-ctx.Done():
-		log.Println("Client disconnected after fetching MP4 stream")
-	case <-done:
-		log.Println("MP4 source has closed the connection")
+		log.Printf("Client (%s) disconnected.\n", r.RemoteAddr)
+		updateConcurrency(selectedUrl.M3UIndex, false)
+		return
 	}
-	updateConcurrency(selectedUrl.M3UIndex, false)
 }
 
 func checkConcurrency(m3uIndex int) bool {

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -213,12 +213,10 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	}()
 
 	// Wait for the request context to be canceled or the stream to finish
-	select {
-	case <-ctx.Done():
-		log.Printf("Client (%s) disconnected.\n", r.RemoteAddr)
-		updateConcurrency(selectedUrl.M3UIndex, false)
-		return
-	}
+	<-ctx.Done()
+	log.Printf("Client (%s) disconnected.\n", r.RemoteAddr)
+	updateConcurrency(selectedUrl.M3UIndex, false)
+	return
 }
 
 func checkConcurrency(m3uIndex int) bool {

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -216,7 +216,6 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	<-ctx.Done()
 	log.Printf("Client (%s) disconnected.\n", r.RemoteAddr)
 	updateConcurrency(selectedUrl.M3UIndex, false)
-	return
 }
 
 func checkConcurrency(m3uIndex int) bool {


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* There are edge cases where an idle connection (while waiting for EOF) is sustained indefinitely.

## Choices

* By having a default buffer, the contents can be checked to see if it's empty or not. If it's empty for a certain timeout period, then cancel the HTTP context altogether and close the connection.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.