### PR TITLE
Properly remove key-value pairs when comma splitting

### DIFF
--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -51,15 +51,7 @@ func parseLine(line string, nextLine string, m3uIndex int) database.StreamInfo {
 			}
 		}
 
-		var pair string
-		if strings.Contains(value, `"`) || strings.Contains(value, ",") {
-			// If the value contains double quotes or commas, format it as key="value"
-			pair = fmt.Sprintf(`%s="%s"`, key, value)
-		} else {
-			// Otherwise, format it as key=value
-			pair = fmt.Sprintf(`%s=%s`, key, value)
-		}
-		lineWithoutPairs = strings.Replace(lineWithoutPairs, pair, "", 1)
+		lineWithoutPairs = strings.Replace(lineWithoutPairs, match[0], "", 1)
 	}
 
 	lineCommaSplit := strings.SplitN(lineWithoutPairs, ",", 2)


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Attributes with values that have commas break the parser. (#58)

## Choices

* By removing all attributes-values pairs before splitting the string with comma as delimiter, the first comma split is guaranteed to be the channel title.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [x] I've not introduced breaking changes.