### PR TITLE
Use source M3U's file extension for streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Currently, nested M3U files are not supported (M3U playlists inside a parent M3U
    - **Playlist Endpoint (`/playlist.m3u`):**
      - Access the merged M3U playlist containing streams from different sources.
 
-   - **Stream Endpoint (`/stream/{streamID}.mp4`):**
-     - Request MP4 streams for specific stream IDs.
+   - **Stream Endpoint (`/stream/{streamID}.{fileExt}`):**
+     - Request video streams for specific stream IDs.
 
 3. **Load Balancing:**
    - The service employs load balancing by cycling through available stream URLs.
@@ -39,7 +39,7 @@ Currently, nested M3U files are not supported (M3U playlists inside a parent M3U
 ## Prerequisites
 
 - [Docker](https://www.docker.com/) installed on your system.
-- M3U URLs containing a playlist of MP4 streams.
+- M3U URLs containing a playlist of video streams.
 
 ## Docker Compose
 
@@ -90,7 +90,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 
 - `/playlist.m3u`: Get the merged M3U playlist.
 
-- `/stream/{streamID}.mp4`: Stream MP4 content for specified stream IDs.
+- `/stream/{streamID}.{fileExt}`: Stream video content for specified stream IDs.
 
 ## Contributing
 

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -23,7 +23,7 @@ func getFileExtensionFromUrl(rawUrl string) (string, error) {
 	return u.Path[pos+1 : len(u.Path)], nil
 }
 
-func generateStreamURL(baseUrl string, title string, sampleUrl string) string {
+func GenerateStreamURL(baseUrl string, title string, sampleUrl string) string {
 	ext, err := getFileExtensionFromUrl(sampleUrl)
 	if err != nil {
 		return fmt.Sprintf("%s/%s\n", baseUrl, utils.GetStreamUID(title))
@@ -65,7 +65,7 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 		}
 
 		// Write stream URL
-		_, err = fmt.Fprintf(w, "%s", generateStreamURL(baseUrl, stream.Title, stream.URLs[0].Content))
+		_, err = fmt.Fprintf(w, "%s", GenerateStreamURL(baseUrl, stream.Title, stream.URLs[0].Content))
 		if err != nil {
 			continue
 		}

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -53,6 +53,10 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 	}
 
 	for _, stream := range streams {
+		if len(stream.URLs) == 0 {
+			continue
+		}
+
 		// Write #EXTINF line
 		_, err := fmt.Fprintf(w, "#EXTINF:-1 tvg-id=\"%s\" tvg-name=\"%s\" tvg-logo=\"%s\" group-title=\"%s\",%s\n",
 			stream.TvgID, stream.Title, stream.LogoURL, stream.Group, stream.Title)

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -61,7 +61,7 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 		}
 
 		// Write stream URL
-		_, err = fmt.Fprintf(w, "%s", generateStreamURL(baseUrl, stream.Title, stream.URLs[0]))
+		_, err = fmt.Fprintf(w, "%s", generateStreamURL(baseUrl, stream.Title, stream.URLs[0].Content))
 		if err != nil {
 			continue
 		}

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -63,7 +63,7 @@ func TestGenerateM3UContent(t *testing.T) {
 	// Check the generated M3U content
 	expectedContent := fmt.Sprintf(`#EXTM3U
 #EXTINF:-1 tvg-id="1" tvg-name="TestStream" tvg-logo="http://example.com/logo.png" group-title="TestGroup",TestStream
-%s`, generateStreamURL("http:///stream", "TestStream"))
+%s`, generateStreamURL("http:///stream", "TestStream", stream.URLs[0].Content))
 	if rr.Body.String() != expectedContent {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expectedContent)

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -68,7 +68,7 @@ func TestGenerateM3UContent(t *testing.T) {
 	// Check the generated M3U content
 	expectedContent := fmt.Sprintf(`#EXTM3U
 #EXTINF:-1 tvg-id="1" tvg-name="TestStream" tvg-logo="http://example.com/logo.png" group-title="TestGroup",TestStream
-%s`, generateStreamURL("http:///stream", "TestStream", stream.URLs[0].Content))
+%s`, GenerateStreamURL("http:///stream", "TestStream", stream.URLs[0].Content))
 	if rr.Body.String() != expectedContent {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expectedContent)

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -27,7 +27,12 @@ func TestGenerateM3UContent(t *testing.T) {
 		t.Errorf("InitializeSQLite returned error: %v", err)
 	}
 
-	_, err = db.InsertStream(stream)
+	id, err := db.InsertStream(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.InsertStreamUrl(id, stream.URLs[0])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -86,7 +86,7 @@ func insertStreamToDb(db *database.Instance, currentStream database.StreamInfo) 
 	}
 
 	if os.Getenv("DEBUG") == "true" {
-		log.Printf("Adding MP4 url entry to %s\n", currentStream.Title)
+		log.Printf("Adding stream url entry to %s\n", currentStream.Title)
 	}
 
 	for _, currentStreamUrl := range currentStream.URLs {

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func main() {
 		m3u.GenerateM3UContent(w, r, db)
 	})
 	http.HandleFunc("/stream/", func(w http.ResponseWriter, r *http.Request) {
-		mp4Handler(w, r, db)
+		streamHandler(w, r, db)
 	})
 
 	// Start the server

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 	// Start the server
 	log.Println("Server is running on port 8080...")
 	log.Println("Playlist Endpoint is running (`/playlist.m3u`)")
-	log.Println("Stream Endpoint is running (`/stream/{streamID}.mp4`)")
+	log.Println("Stream Endpoint is running (`/stream/{streamID}.{fileExt}`)")
 	err = http.ListenAndServe(":8080", nil)
 	if err != nil {
 		log.Fatalf("HTTP server error: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -3,15 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"m3u-stream-merger/database"
 	"m3u-stream-merger/m3u"
-	"m3u-stream-merger/utils"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -60,8 +59,7 @@ func TestStreamHandler(t *testing.T) {
 		wg.Add(1)
 		go func(stream database.StreamInfo) {
 			defer wg.Done()
-			streamUid := utils.GetStreamUID(stream.Title)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/stream/%s.mp4", streamUid), nil)
+			req := httptest.NewRequest("GET", strings.TrimSpace(m3u.GenerateStreamURL("", stream.Title, stream.URLs[0].Content)), nil)
 			w := httptest.NewRecorder()
 
 			// Call the handler function

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 )
 
-func TestMP4Handler(t *testing.T) {
+func TestStreamHandler(t *testing.T) {
 	db, err := database.InitializeSQLite("current_streams")
 	if err != nil {
 		t.Errorf("InitializeSQLite returned error: %v", err)
@@ -65,7 +65,7 @@ func TestMP4Handler(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			// Call the handler function
-			mp4Handler(w, req, db)
+			streamHandler(w, req, db)
 
 			// Check the response status code
 			resp := w.Result()

--- a/mp4_handler.go
+++ b/mp4_handler.go
@@ -106,7 +106,7 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	log.Printf("Received request from %s for URL: %s\n", r.RemoteAddr, r.URL.Path)
 
 	// Extract the m3u ID from the URL path
-	m3uID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/stream/"), ".mp4")
+	m3uID := strings.Split(strings.TrimPrefix(r.URL.Path, "/stream/"), ".")[0]
 	if m3uID == "" {
 		http.NotFound(w, r)
 		return

--- a/stream_handler.go
+++ b/stream_handler.go
@@ -44,7 +44,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 			}
 
 			// Log the error
-			log.Printf("Error fetching MP4 stream (concurrency round robin mode): %s\n", err.Error())
+			log.Printf("Error fetching stream (concurrency round robin mode): %s\n", err.Error())
 
 			lastIndex = (lastIndex + 1) % len(stream.URLs) // Update the last index used
 		}
@@ -67,7 +67,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 			}
 
 			// Log the error
-			log.Printf("Error fetching MP4 stream (concurrency brute force mode): %s\n", err.Error())
+			log.Printf("Error fetching stream (concurrency brute force mode): %s\n", err.Error())
 		}
 	default:
 		log.Printf("Invalid LOAD_BALANCING_MODE. Skipping concurrency mode...")
@@ -83,13 +83,13 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 				break
 			} else {
 				// Log the error
-				log.Printf("Error fetching MP4 stream (connection check mode): %s\n", err.Error())
+				log.Printf("Error fetching stream (connection check mode): %s\n", err.Error())
 			}
 		}
 
 		if resp == nil {
 			// Log the error
-			return nil, nil, fmt.Errorf("Error fetching MP4 stream. Exhausted all streams.")
+			return nil, nil, fmt.Errorf("Error fetching stream. Exhausted all streams.")
 		}
 
 		return resp, selectedUrl, nil
@@ -98,7 +98,7 @@ func loadBalancer(stream database.StreamInfo) (resp *http.Response, selectedUrl 
 	return resp, selectedUrl, nil
 }
 
-func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
+func streamHandler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
@@ -124,11 +124,6 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 		return
 	}
 
-	// You can modify the response header as needed
-	w.Header().Set("Content-Type", "video/mp4")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
 	var resp *http.Response
 	defer func() {
 		if resp != nil && resp.Body != nil {
@@ -141,13 +136,22 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 
 	resp, selectedUrl, err = loadBalancer(stream)
 	if err != nil {
-		http.Error(w, "Error fetching MP4 stream. Exhausted all streams.", http.StatusInternalServerError)
+		http.Error(w, "Error fetching stream. Exhausted all streams.", http.StatusInternalServerError)
 		return
 	}
 	log.Printf("Proxying %s to %s\n", r.RemoteAddr, selectedUrl.Content)
 
 	// Log the successful response
-	log.Printf("Sent MP4 stream to %s\n", r.RemoteAddr)
+	log.Printf("Sent stream to %s\n", r.RemoteAddr)
+
+	for k, v := range resp.Header {
+		for _, val := range v {
+			w.Header().Set(k, val)
+		}
+	}
+
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	// Set initial timer duration
 	timerDuration := 15 * time.Second
@@ -192,7 +196,7 @@ func mp4Handler(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 			}
 			n, err := resp.Body.Read(buffer)
 			if err != nil {
-				log.Printf("Error reading MP4 stream: %s\n", err.Error())
+				log.Printf("Error reading stream: %s\n", err.Error())
 				break
 			}
 			if n > 0 {


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Issue #60 

## Choices

* Using the same file extension as the source M3U will ensure that apps that use the file extensions will have the same behavior as the source M3U.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.