### PR TITLE
Separate group filter for each m3u file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
 | LOAD_BALANCING_MODE                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
 | BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any positive integer |
-| INCLUDE_GROUPS                | Set channel groups to include | all    | Comma-separated values   |
+| INCLUDE_GROUPS_1, INCLUDE_GROUPS_2, INCLUDE_GROUPS_X    | Set channel groups to include | all    | Comma-separated values   |
 | TITLE_SUBSTR_FILTER | Sets a regex pattern used to exclude substrings from channel titles | none    | Go regexp   |
 | TZ                          | Set timezone                                           | Etc/UTC     | [TZ Identifiers](https://nodatime.org/TimeZones) |
 | SYNC_CRON                   | Set cron schedule expression of the background updates. | 0 0 * * *   |  Any valid cron expression    |

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -151,7 +151,7 @@ func ParseM3UFromURL(db *database.Instance, m3uURL string, m3uIndex int) error {
 	var buffer bytes.Buffer
 	var grps []string
 
-	includeGroups := os.Getenv("INCLUDE_GROUPS")
+	includeGroups := os.Getenv(fmt.Sprintf("INCLUDE_GROUPS_%d", m3uIndex))
 	if includeGroups != "" {
 		grps = strings.Split(includeGroups, ",")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ func TestStreamHandler(t *testing.T) {
 
 	os.Setenv("M3U_URL_1", "https://gist.githubusercontent.com/sonroyaalmerol/de1c90e8681af040924da5d15c7f530d/raw/06844df09e69ea278060252ca5aa8d767eb4543d/test-m3u.m3u")
 	os.Setenv("BUFFER_MB", "3")
-	os.Setenv("INCLUDE_GROUPS", "movies")
+	os.Setenv("INCLUDE_GROUPS_1", "movies")
 
 	updateSources(ctx)
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
* Have separate group filter for each m3u file instead of one for all.

## Choices
* Follow same pattern as for M3U_MAX_CONCURRENCY_X and M3U_URL_X

## Test instructions

1. Tested on multiple m3u files, with different group filters.

## Checklist before requesting a review

* [x] I have performed a self-review of my code
* [x] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.