### PR TITLE
fix sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+#Edit with changes i needed from: https://github.com/sonroyaalmerol/m3u-stream-merger-proxy
+
 # 📡 M3U Stream Merger Proxy
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/15a1064c638d4402931fe633b2baa51d)](https://app.codacy.com/gh/sonroyaalmerol/m3u-stream-merger-proxy/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![Docker Pulls](https://img.shields.io/docker/pulls/sonroyaalmerol/m3u-stream-merger-proxy.svg)](https://hub.docker.com/r/sonroyaalmerol/m3u-stream-merger-proxy/) [![](https://img.shields.io/docker/image-size/sonroyaalmerol/m3u-stream-merger-proxy)](https://img.shields.io/docker/image-size/sonroyaalmerol/m3u-stream-merger-proxy) [![Release Images](https://github.com/sonroyaalmerol/m3u-stream-merger-proxy/actions/workflows/release.yml/badge.svg)](https://github.com/sonroyaalmerol/m3u-stream-merger-proxy/actions/workflows/release.yml) [![Developer Images](https://github.com/sonroyaalmerol/m3u-stream-merger-proxy/actions/workflows/developer.yml/badge.svg)](https://github.com/sonroyaalmerol/m3u-stream-merger-proxy/actions/workflows/developer.yml)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ version: '3'
 
 services:
   m3u-stream-merger-proxy:
-    image: sonroyaalmerol/m3u-stream-merger-proxy:latest
+    image: blackwhitebear8/m3u-stream-merger-proxy:latest
     ports:
       - "8080:8080"
     volumes:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-#Edit with changes i needed from: https://github.com/sonroyaalmerol/m3u-stream-merger-proxy
-
 # 📡 M3U Stream Merger Proxy
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/15a1064c638d4402931fe633b2baa51d)](https://app.codacy.com/gh/sonroyaalmerol/m3u-stream-merger-proxy/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![Docker Pulls](https://img.shields.io/docker/pulls/sonroyaalmerol/m3u-stream-merger-proxy.svg)](https://hub.docker.com/r/sonroyaalmerol/m3u-stream-merger-proxy/) [![](https://img.shields.io/docker/image-size/sonroyaalmerol/m3u-stream-merger-proxy)](https://img.shields.io/docker/image-size/sonroyaalmerol/m3u-stream-merger-proxy) [![Release Images](https://github.com/sonroyaalmerol/m3u-stream-merger-proxy/actions/workflows/release.yml/badge.svg)](https://github.com/sonroyaalmerol/m3u-stream-merger-proxy/actions/workflows/release.yml) [![Developer Images](https://github.com/sonroyaalmerol/m3u-stream-merger-proxy/actions/workflows/developer.yml/badge.svg)](https://github.com/sonroyaalmerol/m3u-stream-merger-proxy/actions/workflows/developer.yml)
 
@@ -52,7 +50,7 @@ version: '3'
 
 services:
   m3u-stream-merger-proxy:
-    image: blackwhitebear8/m3u-stream-merger-proxy:latest
+    image: sonroyaalmerol/m3u-stream-merger-proxy:latest
     ports:
       - "8080:8080"
     volumes:

--- a/database/db.go
+++ b/database/db.go
@@ -394,7 +394,7 @@ func (db *Instance) GetStreamUrlByUrlAndIndex(url string, m3u_index int) (s Stre
 }
 
 func (db *Instance) GetStreams() ([]StreamInfo, error) {
-	rows, err := db.Sql.Query("SELECT id, title, tvg_id, logo_url, group_name FROM streams")
+	rows, err := db.Sql.Query("SELECT id, title, tvg_id, logo_url, group_name FROM streams ORDER BY CAST(tvg_id AS INTEGER) ASC")
 	if err != nil {
 		return nil, fmt.Errorf("error querying streams: %v", err)
 	}

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-// getFileExtensionFromUrl haalt de bestandsextensie op van een URL
+// getFileExtensionFromUrl
 func getFileExtensionFromUrl(rawUrl string) (string, error) {
 	u, err := url.Parse(rawUrl)
 	if err != nil {
@@ -26,7 +26,7 @@ func getFileExtensionFromUrl(rawUrl string) (string, error) {
 	return u.Path[pos+1:], nil
 }
 
-// GenerateStreamURL genereert een stream URL
+// GenerateStreamURL
 func GenerateStreamURL(baseUrl string, title string, sampleUrl string) string {
 	ext, err := getFileExtensionFromUrl(sampleUrl)
 	if err != nil {
@@ -35,7 +35,7 @@ func GenerateStreamURL(baseUrl string, title string, sampleUrl string) string {
 	return fmt.Sprintf("%s/%s.%s\n", baseUrl, utils.GetStreamUID(title), ext)
 }
 
-// GenerateM3UContent genereert de M3U-inhoud
+// GenerateM3UContent
 func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	streams, err := db.GetStreams()
 	if err != nil {
@@ -57,12 +57,12 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 		log.Println(fmt.Errorf("Fprintf error: %v", err))
 	}
 
-	// Sorteer de streams op basis van TVG-ID, interpreteer de ID's als getallen
+	// Sort the streams by TVG ID, interpret the IDs as numbers
 	sort.Slice(streams, func(i, j int) bool {
 		id1, err1 := strconv.Atoi(streams[i].TvgID)
 		id2, err2 := strconv.Atoi(streams[j].TvgID)
 		if err1 != nil || err2 != nil {
-			// Als een van de conversies mislukt, vergelijk dan als strings
+			// If any of the conversions fail, compare as strings
 			return streams[i].TvgID < streams[j].TvgID
 		}
 		return id1 < id2
@@ -73,14 +73,14 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 			continue
 		}
 
-		// Schrijf de #EXTINF regel
+		// Write #EXTINF line
 		_, err := fmt.Fprintf(w, "#EXTINF:-1 channelID=\"x-ID.%s\" tvg-chno=\"%s\" tvg-id=\"%s\" tvg-name=\"%s\" tvg-logo=\"%s\" group-title=\"%s\",%s\n",
 			stream.TvgID, stream.TvgID, stream.TvgID, stream.Title, stream.LogoURL, stream.Group, stream.Title)
 		if err != nil {
 			continue
 		}
 
-		// Schrijf de stream URL
+		// Write stream URL
 		_, err = fmt.Fprintf(w, "%s", GenerateStreamURL(baseUrl, stream.Title, stream.URLs[0].Content))
 		if err != nil {
 			continue

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -8,9 +8,12 @@ import (
 	"m3u-stream-merger/utils"
 	"net/http"
 	"net/url"
+	"sort"
+	"strconv"
 	"strings"
 )
 
+// getFileExtensionFromUrl haalt de bestandsextensie op van een URL
 func getFileExtensionFromUrl(rawUrl string) (string, error) {
 	u, err := url.Parse(rawUrl)
 	if err != nil {
@@ -20,9 +23,10 @@ func getFileExtensionFromUrl(rawUrl string) (string, error) {
 	if pos == -1 {
 		return "", errors.New("couldn't find a period to indicate a file extension")
 	}
-	return u.Path[pos+1 : len(u.Path)], nil
+	return u.Path[pos+1:], nil
 }
 
+// GenerateStreamURL genereert een stream URL
 func GenerateStreamURL(baseUrl string, title string, sampleUrl string) string {
 	ext, err := getFileExtensionFromUrl(sampleUrl)
 	if err != nil {
@@ -31,6 +35,7 @@ func GenerateStreamURL(baseUrl string, title string, sampleUrl string) string {
 	return fmt.Sprintf("%s/%s.%s\n", baseUrl, utils.GetStreamUID(title), ext)
 }
 
+// GenerateM3UContent genereert de M3U-inhoud
 func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	streams, err := db.GetStreams()
 	if err != nil {
@@ -52,19 +57,30 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 		log.Println(fmt.Errorf("Fprintf error: %v", err))
 	}
 
+	// Sorteer de streams op basis van TVG-ID, interpreteer de ID's als getallen
+	sort.Slice(streams, func(i, j int) bool {
+		id1, err1 := strconv.Atoi(streams[i].TvgID)
+		id2, err2 := strconv.Atoi(streams[j].TvgID)
+		if err1 != nil || err2 != nil {
+			// Als een van de conversies mislukt, vergelijk dan als strings
+			return streams[i].TvgID < streams[j].TvgID
+		}
+		return id1 < id2
+	})
+
 	for _, stream := range streams {
 		if len(stream.URLs) == 0 {
 			continue
 		}
 
-		// Write #EXTINF line
+		// Schrijf de #EXTINF regel
 		_, err := fmt.Fprintf(w, "#EXTINF:-1 channelID=\"x-ID.%s\" tvg-chno=\"%s\" tvg-id=\"%s\" tvg-name=\"%s\" tvg-logo=\"%s\" group-title=\"%s\",%s\n",
 			stream.TvgID, stream.TvgID, stream.TvgID, stream.Title, stream.LogoURL, stream.Group, stream.Title)
 		if err != nil {
 			continue
 		}
 
-		// Write stream URL
+		// Schrijf de stream URL
 		_, err = fmt.Fprintf(w, "%s", GenerateStreamURL(baseUrl, stream.Title, stream.URLs[0].Content))
 		if err != nil {
 			continue

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -58,8 +58,8 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 		}
 
 		// Write #EXTINF line
-		_, err := fmt.Fprintf(w, "#EXTINF:-1 tvg-id=\"%s\" tvg-name=\"%s\" tvg-logo=\"%s\" group-title=\"%s\",%s\n",
-			stream.TvgID, stream.Title, stream.LogoURL, stream.Group, stream.Title)
+		_, err := fmt.Fprintf(w, "#EXTINF:-1 channelID=\"x-ID.%s\" tvg-chno=\"%s\" tvg-id=\"%s\" tvg-name=\"%s\" tvg-logo=\"%s\" group-title=\"%s\",%s\n",
+			stream.TvgID, stream.TvgID, stream.TvgID, stream.Title, stream.LogoURL, stream.Group, stream.Title)
 		if err != nil {
 			continue
 		}

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 )
 
-// getFileExtensionFromUrl
 func getFileExtensionFromUrl(rawUrl string) (string, error) {
 	u, err := url.Parse(rawUrl)
 	if err != nil {
@@ -26,7 +25,6 @@ func getFileExtensionFromUrl(rawUrl string) (string, error) {
 	return u.Path[pos+1:], nil
 }
 
-// GenerateStreamURL
 func GenerateStreamURL(baseUrl string, title string, sampleUrl string) string {
 	ext, err := getFileExtensionFromUrl(sampleUrl)
 	if err != nil {
@@ -35,7 +33,6 @@ func GenerateStreamURL(baseUrl string, title string, sampleUrl string) string {
 	return fmt.Sprintf("%s/%s.%s\n", baseUrl, utils.GetStreamUID(title), ext)
 }
 
-// GenerateM3UContent
 func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Instance) {
 	streams, err := db.GetStreams()
 	if err != nil {
@@ -56,17 +53,6 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 	if err != nil {
 		log.Println(fmt.Errorf("Fprintf error: %v", err))
 	}
-
-	// Sort the streams by TVG ID, interpret the IDs as numbers
-	sort.Slice(streams, func(i, j int) bool {
-		id1, err1 := strconv.Atoi(streams[i].TvgID)
-		id2, err2 := strconv.Atoi(streams[j].TvgID)
-		if err1 != nil || err2 != nil {
-			// If any of the conversions fail, compare as strings
-			return streams[i].TvgID < streams[j].TvgID
-		}
-		return id1 < id2
-	})
 
 	for _, stream := range streams {
 		if len(stream.URLs) == 0 {

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -8,8 +8,6 @@ import (
 	"m3u-stream-merger/utils"
 	"net/http"
 	"net/url"
-	"sort"
-	"strconv"
 	"strings"
 )
 

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -67,7 +67,7 @@ func TestGenerateM3UContent(t *testing.T) {
 
 	// Check the generated M3U content
 	expectedContent := fmt.Sprintf(`#EXTM3U
-#EXTINF:-1 tvg-id="1" tvg-name="TestStream" tvg-logo="http://example.com/logo.png" group-title="TestGroup",TestStream
+#EXTINF:-1 channelID="x-ID.1" tvg-chno="1" tvg-id="1" tvg-name="TestStream" tvg-logo="http://example.com/logo.png" group-title="TestGroup",TestStream
 %s`, GenerateStreamURL("http:///stream", "TestStream", stream.URLs[0].Content))
 	if rr.Body.String() != expectedContent {
 		t.Errorf("handler returned unexpected body: got %v want %v",
@@ -89,14 +89,14 @@ func TestGenerateM3UContent(t *testing.T) {
 func TestParseM3UFromURL(t *testing.T) {
 	testM3UContent := `
 #EXTM3U
-#EXTINF:-1 tvg-id="bbc1" tvg-name="BBC One" group-title="UK",BBC One
+#EXTINF:-1 channelID="x-ID.bcc1" tvg-chno="bcc1" tvg-id="bbc1" tvg-name="BBC One" group-title="UK",BBC One
 http://example.com/bbc1
-#EXTINF:-1 tvg-id="bbc2" tvg-name="BBC Two" group-title="UK",BBC Two
+#EXTINF:-1 channelID="x-ID.bcc2" tvg-chno="bbc2" tvg-id="bbc2" tvg-name="BBC Two" group-title="UK",BBC Two
 http://example.com/bbc2
-#EXTINF:-1 tvg-id="cnn" tvg-name="CNN International" group-title="News",CNN International
+#EXTINF:-1 channelID="x-ID.cnn" tvg-chno="cnn" tvg-id="cnn" tvg-name="CNN International" group-title="News",CNN International
 http://example.com/cnn
 #EXTVLCOPT:logo=http://example.com/bbc_logo.png
-#EXTINF:-1 tvg-id="fox" tvg-name="FOX" group-title="Entertainment",FOX
+#EXTINF:-1 channelID="x-ID.fox" tvg-chno="fox" tvg-id="fox" tvg-name="FOX" group-title="Entertainment",FOX
 http://example.com/fox
 `
 	// Create a mock HTTP server


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

Fixed the channel sorting and added channel numbers. Now when it generates the new m3u it adds the channel numbers in various formats again so Emby can understand it. And it will now at all times sort the m3u from the lowest channel id to the highest instead of random.

## Choices

so it works

## Test instructions

i builded the docker container on my pc and pushed it to dockerhub and tested it on my setup and it works.

## Checklist before requesting a review

* [ x] I have performed a self-review of my code
* [ x] I've added documentation about this change to the README.
* [ x] I've not introduced breaking changes.