### PR TITLE
Remove load-balancer modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | M3U_URL_1, M3U_URL_2, M3U_URL_X | Set M3U URLs as environment variables.                  |   N/A            |   Any valid M3U URLs                                             |
 | M3U_MAX_CONCURRENCY_1, M3U_MAX_CONCURRENCY_2, M3U_MAX_CONCURRENCY_X | Set max concurrency.                                 |  1             |   Any integer                                             |
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
-| LOAD_BALANCING_MODE                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
+| ~~LOAD_BALANCING_MODE~~ (removed on version 0.10.0)                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
 | BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any positive integer |
 | INCLUDE_GROUPS_1, INCLUDE_GROUPS_2, INCLUDE_GROUPS_X    | Set channel groups to include | all    | Comma-separated values   |
 | TITLE_SUBSTR_FILTER | Sets a regex pattern used to exclude substrings from channel titles | none    | Go regexp   |

--- a/stream_handler.go
+++ b/stream_handler.go
@@ -15,8 +15,8 @@ import (
 )
 
 func loadBalancer(stream database.StreamInfo) (*http.Response, *database.StreamURL, error) {
-	sort.Slice(stream.URLs, func(i, j database.StreamURL) bool {
-		return concurrencyPriorityValue(i.M3UIndex) > concurrencyPriorityValue(j.M3UIndex)
+	sort.Slice(stream.URLs, func(i, j int) bool {
+		return concurrencyPriorityValue(stream.URLs[i].M3UIndex) > concurrencyPriorityValue(stream.URLs[j].M3UIndex)
 	})
 
 	lap := 0


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Remove load-balancing algo options and make the default (and only) mode smarter.

## Choices

* LB algos like round-robin are "stateful" which will require too much effort for its use and purposes.

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.