### PR TITLE
Ignore content-length header from source

### DIFF
--- a/stream_handler.go
+++ b/stream_handler.go
@@ -116,7 +116,7 @@ func streamHandler(w http.ResponseWriter, r *http.Request, db *database.Instance
 	for k, v := range resp.Header {
 		for _, val := range v {
 			if strings.ToLower(k) == "content-length" {
-				continue
+				break
 			}
 			w.Header().Set(k, val)
 		}

--- a/stream_handler.go
+++ b/stream_handler.go
@@ -115,6 +115,9 @@ func streamHandler(w http.ResponseWriter, r *http.Request, db *database.Instance
 
 	for k, v := range resp.Header {
 		for _, val := range v {
+			if strings.ToLower(k) == "content-length" {
+				continue
+			}
 			w.Header().Set(k, val)
 		}
 	}


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* When switching from one source to another, the returned Content-Length header becomes stale and produces the "wrote more than the declared Content-Length" error. Not returning any content-length headers would fix this.

## Choices

* <!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.