### PR TITLE
Use base 0 for m3u index

### DIFF
--- a/database/concurrency_utils.go
+++ b/database/concurrency_utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (db *Instance) ConcurrencyPriorityValue(m3uIndex int) int {
-	maxConcurrency, err := strconv.Atoi(os.Getenv(fmt.Sprintf("M3U_MAX_CONCURRENCY_%d", m3uIndex)))
+	maxConcurrency, err := strconv.Atoi(os.Getenv(fmt.Sprintf("M3U_MAX_CONCURRENCY_%d", m3uIndex+1)))
 	if err != nil {
 		maxConcurrency = 1
 	}
@@ -22,7 +22,7 @@ func (db *Instance) ConcurrencyPriorityValue(m3uIndex int) int {
 }
 
 func (db *Instance) CheckConcurrency(m3uIndex int) bool {
-	maxConcurrency, err := strconv.Atoi(os.Getenv(fmt.Sprintf("M3U_MAX_CONCURRENCY_%d", m3uIndex)))
+	maxConcurrency, err := strconv.Atoi(os.Getenv(fmt.Sprintf("M3U_MAX_CONCURRENCY_%d", m3uIndex+1)))
 	if err != nil {
 		maxConcurrency = 1
 	}
@@ -33,7 +33,7 @@ func (db *Instance) CheckConcurrency(m3uIndex int) bool {
 		return false
 	}
 
-	log.Printf("Current number of connections for M3U_%d: %d", m3uIndex, count)
+	log.Printf("Current number of connections for M3U_%d: %d", m3uIndex+1, count)
 	return count >= maxConcurrency
 }
 
@@ -52,5 +52,5 @@ func (db *Instance) UpdateConcurrency(m3uIndex int, incr bool) {
 	if err != nil {
 		log.Printf("Error checking concurrency: %s\n", err.Error())
 	}
-	log.Printf("Current number of connections for M3U_%d: %d", m3uIndex, count)
+	log.Printf("Current number of connections for M3U_%d: %d", m3uIndex+1, count)
 }

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -108,7 +108,7 @@ func ParseM3UFromURL(db *database.Instance, m3uURL string, m3uIndex int) error {
 	var buffer bytes.Buffer
 	var grps []string
 
-	includeGroups := os.Getenv(fmt.Sprintf("INCLUDE_GROUPS_%d", m3uIndex))
+	includeGroups := os.Getenv(fmt.Sprintf("INCLUDE_GROUPS_%d", m3uIndex+1))
 	if includeGroups != "" {
 		grps = strings.Split(includeGroups, ",")
 	}

--- a/main.go
+++ b/main.go
@@ -20,12 +20,12 @@ var db *database.Instance
 var cronMutex sync.Mutex
 
 func updateSource(nextDb *database.Instance, m3uUrl string, index int) {
-	log.Printf("Background process: Updating M3U #%d from %s\n", index, m3uUrl)
+	log.Printf("Background process: Updating M3U #%d from %s\n", index+1, m3uUrl)
 	err := m3u.ParseM3UFromURL(nextDb, m3uUrl, index)
 	if err != nil {
 		log.Printf("Background process: Error updating M3U: %v\n", err)
 	} else {
-		log.Printf("Background process: Updated M3U #%d from %s\n", index, m3uUrl)
+		log.Printf("Background process: Updated M3U #%d from %s\n", index+1, m3uUrl)
 	}
 }
 
@@ -40,14 +40,14 @@ func updateSources(ctx context.Context) {
 	default:
 		log.Println("Background process: Checking M3U_URLs...")
 		var wg sync.WaitGroup
-		index := 1
+		index := 0
 		for {
-			m3uUrl, m3uExists := os.LookupEnv(fmt.Sprintf("M3U_URL_%d", index))
+			m3uUrl, m3uExists := os.LookupEnv(fmt.Sprintf("M3U_URL_%d", index+1))
 			if !m3uExists {
 				break
 			}
 
-			log.Printf("Background process: Fetching M3U_URL_%d...\n", index)
+			log.Printf("Background process: Fetching M3U_URL_%d...\n", index+1)
 			wg.Add(1)
 			// Start the goroutine for periodic updates
 			go func(currDb *database.Instance, m3uUrl string, index int) {

--- a/stream_handler.go
+++ b/stream_handler.go
@@ -41,7 +41,7 @@ func loadBalancer(stream database.StreamInfo, prevUrl *database.StreamURL) (*htt
 		}
 
 		if db.CheckConcurrency(url.M3UIndex) {
-			log.Printf("Concurrency limit reached for M3U_%d: %s", url.M3UIndex, url.Content)
+			log.Printf("Concurrency limit reached for M3U_%d: %s", url.M3UIndex+1, url.Content)
 			continue
 		}
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* This is probably the source of most bugs for the load balancer so far. Some parts of the code were confusing due to the term "index" which implies that the value starts from 0 but actually starts from 1.

## Choices

* Make all values start from 0 then +1 when printing to a log and for env vars to prevent breaking changes from config.

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.