### PR TITLE
Use a worker pool pattern to limit the number of goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | REDIS_DB | Set Redis server database to be used | 0 | 0 to 15 |
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
 | ~~LOAD_BALANCING_MODE~~ (removed on version 0.10.0)                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
+| PARSER_WORKERS | Set number of workers to spawn for M3U parsing. | 5 | Any positive integer |
 | BUFFER_MB | Set buffer size in mb. | 0 (no buffer) | Any positive integer |
 | INCLUDE_GROUPS_1, INCLUDE_GROUPS_2, INCLUDE_GROUPS_X    | Set channel groups to include | all    | Comma-separated values   |
 | TITLE_SUBSTR_FILTER | Sets a regex pattern used to exclude substrings from channel titles | none    | Go regexp   |


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Fix spawning too much workers for parsing causing some workers to crash due to low resources (#72)

## Choices

* Use a worker pool pattern to limit the number of goroutines

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.