### PR TITLE
Add option to change key being used by the database sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | REDIS_ADDR | Set Redis server address | N/A | e.g. localhost:6379 |
 | REDIS_PASS | Set Redis server password | N/A | Any string |
 | REDIS_DB | Set Redis server database to be used | 0 | 0 to 15 |
+| SORTING_KEY | Set tag to be used for sorting the stream list | tvg-id | tvg-id, tvg-chno |
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
 | ~~LOAD_BALANCING_MODE~~ (removed on version 0.10.0)                | Set load balancing algorithm to a specific mode | brute-force    | brute-force/round-robin   |
 | PARSER_WORKERS | Set number of workers to spawn for M3U parsing. | 5 | Any positive integer |

--- a/database/db.go
+++ b/database/db.go
@@ -13,9 +13,8 @@ import (
 )
 
 type Instance struct {
-	Redis      *redis.Client
-	Ctx        context.Context
-	SortingKey string
+	Redis *redis.Client
+	Ctx   context.Context
 }
 
 func InitializeDb(addr string, password string, db int) (*Instance, error) {
@@ -38,7 +37,7 @@ func InitializeDb(addr string, password string, db int) (*Instance, error) {
 		return nil, fmt.Errorf("error connecting to Redis: %v", err)
 	}
 
-	return &Instance{Redis: redisInstance, Ctx: context.Background(), SortingKey: "tvg-id"}, nil
+	return &Instance{Redis: redisInstance, Ctx: context.Background()}, nil
 }
 
 func (db *Instance) ClearDb() error {

--- a/database/db.go
+++ b/database/db.go
@@ -210,10 +210,7 @@ func (db *Instance) GetStreamUrlByUrlAndIndex(url string, m3u_index int) (Stream
 }
 
 func (db *Instance) GetStreams() ([]StreamInfo, error) {
-	var keys []string
-	var err error
-
-	keys, err = db.Redis.ZRange(db.Ctx, "streams_sorted", 0, -1).Result()
+	keys, err := db.Redis.ZRange(db.Ctx, "streams_sorted", 0, -1).Result()
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving streams: %v", err)
 	}

--- a/database/types.go
+++ b/database/types.go
@@ -3,6 +3,7 @@ package database
 type StreamInfo struct {
 	Title   string
 	TvgID   string
+	TvgChNo string
 	LogoURL string
 	Group   string
 	URLs    []StreamURL

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -59,7 +59,7 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 
 		// Write #EXTINF line
 		_, err := fmt.Fprintf(w, "#EXTINF:-1 channelID=\"x-ID.%s\" tvg-chno=\"%s\" tvg-id=\"%s\" tvg-name=\"%s\" tvg-logo=\"%s\" group-title=\"%s\",%s\n",
-			stream.TvgID, stream.TvgID, stream.TvgID, stream.Title, stream.LogoURL, stream.Group, stream.Title)
+			stream.TvgID, stream.TvgChNo, stream.TvgID, stream.Title, stream.LogoURL, stream.Group, stream.Title)
 		if err != nil {
 			continue
 		}

--- a/m3u/middlewares.go
+++ b/m3u/middlewares.go
@@ -34,6 +34,10 @@ func tvgIdParser(value string) string {
 	return generalParser(value)
 }
 
+func tvgChNoParser(value string) string {
+	return generalParser(value)
+}
+
 func groupTitleParser(value string) string {
 	return generalParser(value)
 }

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -39,6 +39,8 @@ func parseLine(line string, nextLine string, m3uIndex int) database.StreamInfo {
 		switch strings.ToLower(key) {
 		case "tvg-id":
 			currentStream.TvgID = tvgIdParser(value)
+		case "tvg-chno":
+			currentStream.TvgChNo = tvgChNoParser(value)
 		case "tvg-name":
 			currentStream.Title = tvgNameParser(value)
 		case "group-title":


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* #68 introduced a regression for m3u providers that don't use tvg-id.

## Choices

* Add `SORTING_KEY` env var to set the tag to be used for sorting.

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.