### PR TITLE
Optimize Redis queries and inserts

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -63,9 +63,9 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 		}
 	}
 
-	err = db.DeleteStreamByTitle(expected[1].Title)
+	err = db.DeleteStreamBySlug(expected[1].Slug)
 	if err != nil {
-		t.Errorf("DeleteStreamByTitle returned error: %v", err)
+		t.Errorf("DeleteStreamBySlug returned error: %v", err)
 	}
 
 	err = db.DeleteStreamURL(expected[0], expected[0].URLs[0].M3UIndex)
@@ -95,7 +95,7 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 
 // streamInfoEqual checks if two StreamInfo objects are equal.
 func streamInfoEqual(a, b StreamInfo) bool {
-	if a.TvgID != b.TvgID || a.Title != b.Title || a.Group != b.Group || a.LogoURL != b.LogoURL || len(a.URLs) != len(b.URLs) {
+	if a.Slug != b.Slug || a.TvgID != b.TvgID || a.Title != b.Title || a.Group != b.Group || a.LogoURL != b.LogoURL || len(a.URLs) != len(b.URLs) {
 		return false
 	}
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -22,6 +22,7 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 
 	// Test LoadFromDb with existing data in the database
 	expected := []StreamInfo{{
+		Slug:    "stream1",
 		Title:   "stream1",
 		TvgID:   "test1",
 		LogoURL: "http://test.com/image.png",
@@ -31,6 +32,7 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 			M3UIndex: 1,
 		}},
 	}, {
+		Slug:    "stream1",
 		Title:   "stream2",
 		TvgID:   "test2",
 		LogoURL: "http://test2.com/image.png",

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -32,7 +32,7 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 			M3UIndex: 1,
 		}},
 	}, {
-		Slug:    "stream1",
+		Slug:    "stream2",
 		Title:   "stream2",
 		TvgID:   "test2",
 		LogoURL: "http://test2.com/image.png",

--- a/database/db.go
+++ b/database/db.go
@@ -48,70 +48,39 @@ func (db *Instance) ClearDb() error {
 }
 
 func (db *Instance) SaveToDb(streams []StreamInfo) error {
+	pipeline := db.Redis.Pipeline()
+
 	for _, s := range streams {
-		if err := db.InsertStream(s); err != nil {
-			return fmt.Errorf("SaveToDb error: %v", err)
+		streamKey := fmt.Sprintf("stream:%s", s.Slug)
+		streamData := map[string]interface{}{
+			"title":      s.Title,
+			"tvg_id":     s.TvgID,
+			"tvg_chno":   s.TvgChNo,
+			"logo_url":   s.LogoURL,
+			"group_name": s.Group,
 		}
+		pipeline.HSet(db.Ctx, streamKey, streamData)
 
 		for _, u := range s.URLs {
-			if err := db.InsertStreamUrl(s, u); err != nil {
-				return fmt.Errorf("SaveToDb error: %v", err)
+			streamURLKey := fmt.Sprintf("stream:%s:url:%d", s.Slug, u.M3UIndex)
+			urlData := map[string]interface{}{
+				"content":   u.Content,
+				"m3u_index": u.M3UIndex,
 			}
+			pipeline.HSet(db.Ctx, streamURLKey, urlData)
 		}
+
+		// Add to the sorted set
+		sortScore := calculateSortScore(s)
+		pipeline.ZAdd(db.Ctx, "streams_sorted", redis.Z{
+			Score:  sortScore,
+			Member: streamKey,
+		})
 	}
 
-	return nil
-}
-
-func (db *Instance) InsertStream(s StreamInfo) error {
-	streamKey := fmt.Sprintf("stream:%s", s.Slug)
-	streamData := map[string]interface{}{
-		"title":      s.Title,
-		"tvg_id":     s.TvgID,
-		"tvg_chno":   s.TvgChNo,
-		"logo_url":   s.LogoURL,
-		"group_name": s.Group,
-	}
-
-	if err := db.Redis.HSet(db.Ctx, streamKey, streamData).Err(); err != nil {
-		return fmt.Errorf("error inserting stream to Redis: %v", err)
-	}
-
-	// Add to the sorted set with tvg_id as the score
-	maxLen := 20
-	base := float64(256)
-
-	// Normalize length by padding the string
-	paddedString := strings.ToLower(getSortingValue(s))
-	if len(paddedString) < maxLen {
-		paddedString = paddedString + strings.Repeat("\x00", maxLen-len(paddedString))
-	}
-
-	sortScore := 0.0
-	for i := 0; i < len(paddedString); i++ {
-		charValue := float64(paddedString[i])
-		sortScore += charValue / math.Pow(base, float64(i+1))
-	}
-
-	if err := db.Redis.ZAdd(db.Ctx, "streams_sorted", redis.Z{
-		Score:  sortScore,
-		Member: streamKey,
-	}).Err(); err != nil {
-		return fmt.Errorf("error adding stream to sorted set: %v", err)
-	}
-
-	return nil
-}
-
-func (db *Instance) InsertStreamUrl(s StreamInfo, url StreamURL) error {
-	streamKey := fmt.Sprintf("stream:%s:url:%d", s.Slug, url.M3UIndex)
-	urlData := map[string]interface{}{
-		"content":   url.Content,
-		"m3u_index": url.M3UIndex,
-	}
-
-	if err := db.Redis.HSet(db.Ctx, streamKey, urlData).Err(); err != nil {
-		return fmt.Errorf("error inserting stream URL to Redis: %v", err)
+	_, err := pipeline.Exec(db.Ctx)
+	if err != nil {
+		return fmt.Errorf("SaveToDb error: %v", err)
 	}
 
 	return nil
@@ -121,13 +90,22 @@ func (db *Instance) DeleteStreamBySlug(slug string) error {
 	streamKey := fmt.Sprintf("stream:%s", slug)
 
 	// Delete associated URLs
-	keys, err := db.Redis.Keys(db.Ctx, fmt.Sprintf("%s:url:*", streamKey)).Result()
-	if err != nil {
-		return fmt.Errorf("error finding associated URLs: %v", err)
-	}
-	for _, key := range keys {
-		if err := db.Redis.Del(db.Ctx, key).Err(); err != nil {
-			return fmt.Errorf("error deleting stream URL from Redis: %v", err)
+	cursor := uint64(0)
+	for {
+		keys, newCursor, err := db.Redis.Scan(db.Ctx, cursor, fmt.Sprintf("%s:url:*", streamKey), 10).Result()
+		if err != nil {
+			return fmt.Errorf("error scanning associated URLs: %v", err)
+		}
+
+		for _, key := range keys {
+			if err := db.Redis.Del(db.Ctx, key).Err(); err != nil {
+				return fmt.Errorf("error deleting stream URL from Redis: %v", err)
+			}
+		}
+
+		cursor = newCursor
+		if cursor == 0 {
+			break
 		}
 	}
 
@@ -172,51 +150,42 @@ func (db *Instance) GetStreamBySlug(slug string) (StreamInfo, error) {
 		Group:   streamData["group_name"],
 	}
 
-	// Fetch URLs
-	keys, err := db.Redis.Keys(db.Ctx, fmt.Sprintf("%s:url:*", streamKey)).Result()
-	if err != nil {
-		return s, fmt.Errorf("error finding URLs for stream: %v", err)
-	}
-
-	for _, key := range keys {
-		urlData, err := db.Redis.HGetAll(db.Ctx, key).Result()
+	cursor := uint64(0)
+	for {
+		keys, newCursor, err := db.Redis.Scan(db.Ctx, cursor, fmt.Sprintf("%s:url:*", streamKey), 10).Result()
 		if err != nil {
-			return s, fmt.Errorf("error getting URL data from Redis: %v", err)
+			return s, fmt.Errorf("error finding URLs for stream: %v", err)
 		}
 
-		m3uIndex, _ := strconv.Atoi(urlData["m3u_index"])
-		u := StreamURL{
-			Content:  urlData["content"],
-			M3UIndex: m3uIndex,
+		if len(keys) > 0 {
+			results, err := db.Redis.Pipelined(db.Ctx, func(pipe redis.Pipeliner) error {
+				for _, key := range keys {
+					pipe.HGetAll(db.Ctx, key)
+				}
+				return nil
+			})
+			if err != nil {
+				return s, fmt.Errorf("error getting URL data from Redis: %v", err)
+			}
+
+			for _, result := range results {
+				urlData := result.(*redis.MapStringStringCmd).Val()
+				m3uIndex, _ := strconv.Atoi(urlData["m3u_index"])
+				u := StreamURL{
+					Content:  urlData["content"],
+					M3UIndex: m3uIndex,
+				}
+				s.URLs = append(s.URLs, u)
+			}
 		}
-		s.URLs = append(s.URLs, u)
+
+		cursor = newCursor
+		if cursor == 0 {
+			break
+		}
 	}
 
 	return s, nil
-}
-
-func (db *Instance) GetStreamUrlByUrlAndIndex(url string, m3u_index int) (StreamURL, error) {
-	keys, err := db.Redis.Keys(db.Ctx, fmt.Sprintf("stream:*:url:%d", m3u_index)).Result()
-	if err != nil {
-		return StreamURL{}, fmt.Errorf("error finding URL by index: %v", err)
-	}
-
-	for _, key := range keys {
-		urlData, err := db.Redis.HGetAll(db.Ctx, key).Result()
-		if err != nil {
-			return StreamURL{}, fmt.Errorf("error getting URL data from Redis: %v", err)
-		}
-
-		if urlData["content"] == url {
-			m3uIndex, _ := strconv.Atoi(urlData["m3u_index"])
-			return StreamURL{
-				Content:  urlData["content"],
-				M3UIndex: m3uIndex,
-			}, nil
-		}
-	}
-
-	return StreamURL{}, fmt.Errorf("stream URL not found: %s, index: %d", url, m3u_index)
 }
 
 func (db *Instance) GetStreams() ([]StreamInfo, error) {
@@ -225,15 +194,69 @@ func (db *Instance) GetStreams() ([]StreamInfo, error) {
 		return nil, fmt.Errorf("error retrieving streams: %v", err)
 	}
 
+	// Create a slice to hold the final stream data
 	var streams []StreamInfo
+	streamKeys := make([]string, 0, len(keys))
+
+	// Filter out URL keys
 	for _, key := range keys {
-		if !strings.Contains(key, ":url:") { // Exclude URL keys
-			s, err := db.GetStreamBySlug(extractSlug(key))
-			if err != nil {
-				return nil, err
-			}
-			streams = append(streams, s)
+		if !strings.Contains(key, ":url:") {
+			streamKeys = append(streamKeys, key)
 		}
+	}
+
+	// Use a pipeline to fetch all stream data in one go
+	pipe := db.Redis.Pipeline()
+	cmds := make([]*redis.MapStringStringCmd, len(streamKeys))
+
+	for i, key := range streamKeys {
+		cmds[i] = pipe.HGetAll(db.Ctx, key)
+	}
+
+	// Execute the pipeline
+	_, err = pipe.Exec(db.Ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error executing Redis pipeline: %v", err)
+	}
+
+	// Process the results
+	for i, cmd := range cmds {
+		streamData := cmd.Val()
+		if len(streamData) == 0 {
+			continue
+		}
+
+		slug := extractSlug(streamKeys[i])
+		stream := StreamInfo{
+			Slug:    slug,
+			Title:   streamData["title"],
+			TvgID:   streamData["tvg_id"],
+			TvgChNo: streamData["tvg_chno"],
+			LogoURL: streamData["logo_url"],
+			Group:   streamData["group_name"],
+		}
+
+		// Fetch URLs (you may want to optimize URL fetching similarly)
+		urlKeys, err := db.Redis.Keys(db.Ctx, fmt.Sprintf("%s:url:*", streamKeys[i])).Result()
+		if err != nil {
+			return nil, fmt.Errorf("error finding URLs for stream: %v", err)
+		}
+
+		for _, urlKey := range urlKeys {
+			urlData, err := db.Redis.HGetAll(db.Ctx, urlKey).Result()
+			if err != nil {
+				return nil, fmt.Errorf("error getting URL data from Redis: %v", err)
+			}
+
+			m3uIndex, _ := strconv.Atoi(urlData["m3u_index"])
+			u := StreamURL{
+				Content:  urlData["content"],
+				M3UIndex: m3uIndex,
+			}
+			stream.URLs = append(stream.URLs, u)
+		}
+
+		streams = append(streams, stream)
 	}
 
 	return streams, nil
@@ -296,4 +319,24 @@ func getSortingValue(s StreamInfo) string {
 	}
 
 	return s.TvgID + s.Title
+}
+
+func calculateSortScore(s StreamInfo) float64 {
+	// Add to the sorted set with tvg_id as the score
+	maxLen := 20
+	base := float64(256)
+
+	// Normalize length by padding the string
+	paddedString := strings.ToLower(getSortingValue(s))
+	if len(paddedString) < maxLen {
+		paddedString = paddedString + strings.Repeat("\x00", maxLen-len(paddedString))
+	}
+
+	sortScore := 0.0
+	for i := 0; i < len(paddedString); i++ {
+		charValue := float64(paddedString[i])
+		sortScore += charValue / math.Pow(base, float64(i+1))
+	}
+
+	return sortScore
 }

--- a/database/db.go
+++ b/database/db.go
@@ -164,6 +164,7 @@ func (db *Instance) GetStreamBySlug(slug string) (StreamInfo, error) {
 	}
 
 	s := StreamInfo{
+		Slug:    slug,
 		Title:   streamData["title"],
 		TvgID:   streamData["tvg_id"],
 		TvgChNo: streamData["tvg_chno"],

--- a/database/db.go
+++ b/database/db.go
@@ -238,7 +238,6 @@ func (db *Instance) GetStreams() ([]StreamInfo, error) {
 			Group:   streamData["group_name"],
 		}
 
-		// Fetch URLs (you may want to optimize URL fetching similarly)
 		urlKeys, err := db.Redis.Keys(db.Ctx, fmt.Sprintf("%s:url:*", streamKeys[i])).Result()
 		if err != nil {
 			return nil, fmt.Errorf("error finding URLs for stream: %v", err)

--- a/database/db.go
+++ b/database/db.go
@@ -153,15 +153,15 @@ func (db *Instance) DeleteStreamURL(s StreamInfo, m3uIndex int) error {
 	return nil
 }
 
-func (db *Instance) GetStreamByTitle(title string) (StreamInfo, error) {
-	streamKey := fmt.Sprintf("stream:%s", slug.Make(title))
+func (db *Instance) GetStreamBySlug(slug string) (StreamInfo, error) {
+	streamKey := fmt.Sprintf("stream:%s", slug)
 	streamData, err := db.Redis.HGetAll(db.Ctx, streamKey).Result()
 	if err != nil {
 		return StreamInfo{}, fmt.Errorf("error getting stream from Redis: %v", err)
 	}
 
 	if len(streamData) == 0 {
-		return StreamInfo{}, fmt.Errorf("stream not found: %s", title)
+		return StreamInfo{}, fmt.Errorf("stream not found: %s", slug)
 	}
 
 	s := StreamInfo{
@@ -228,7 +228,7 @@ func (db *Instance) GetStreams() ([]StreamInfo, error) {
 	var streams []StreamInfo
 	for _, key := range keys {
 		if !strings.Contains(key, ":url:") { // Exclude URL keys
-			s, err := db.GetStreamByTitle(extractTitle(key))
+			s, err := db.GetStreamBySlug(extractSlug(key))
 			if err != nil {
 				return nil, err
 			}
@@ -277,7 +277,7 @@ func (db *Instance) ClearConcurrencies() error {
 	return nil
 }
 
-func extractTitle(key string) string {
+func extractSlug(key string) string {
 	parts := strings.Split(key, ":")
 	if len(parts) > 1 {
 		return parts[1]

--- a/database/db.go
+++ b/database/db.go
@@ -78,9 +78,11 @@ func (db *Instance) SaveToDb(streams []StreamInfo) error {
 		})
 	}
 
-	_, err := pipeline.Exec(db.Ctx)
-	if err != nil {
-		return fmt.Errorf("SaveToDb error: %v", err)
+	if len(streams) > 0 {
+		_, err := pipeline.Exec(db.Ctx)
+		if err != nil {
+			return fmt.Errorf("SaveToDb error: %v", err)
+		}
 	}
 
 	return nil

--- a/database/db.go
+++ b/database/db.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gosimple/slug"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -118,8 +117,8 @@ func (db *Instance) InsertStreamUrl(s StreamInfo, url StreamURL) error {
 	return nil
 }
 
-func (db *Instance) DeleteStreamByTitle(title string) error {
-	streamKey := fmt.Sprintf("stream:%s", slug.Make(title))
+func (db *Instance) DeleteStreamBySlug(slug string) error {
+	streamKey := fmt.Sprintf("stream:%s", slug)
 
 	// Delete associated URLs
 	keys, err := db.Redis.Keys(db.Ctx, fmt.Sprintf("%s:url:*", streamKey)).Result()

--- a/database/types.go
+++ b/database/types.go
@@ -1,6 +1,7 @@
 package database
 
 type StreamInfo struct {
+	Slug    string
 	Title   string
 	TvgID   string
 	TvgChNo string

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module m3u-stream-merger
 go 1.22.1
 
 require (
+	github.com/gosimple/slug v1.14.0
 	github.com/redis/go-redis/v9 v9.6.1
 	github.com/robfig/cron/v3 v3.0.1
 )
@@ -10,4 +11,5 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/gosimple/unidecode v1.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/gosimple/slug v1.14.0 h1:RtTL/71mJNDfpUbCOmnf/XFkzKRtD6wL6Uy+3akm4Es=
+github.com/gosimple/slug v1.14.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
+github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
+github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/redis/go-redis/v9 v9.6.1 h1:HHDteefn6ZkTtY5fGUE8tj8uy85AHk6zP7CpzIAM0y4=
 github.com/redis/go-redis/v9 v9.6.1/go.mod h1:0C0c6ycQsdpVNQpxb1njEQIqkx5UcsM8FJCQLgE9+RA=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -23,12 +23,12 @@ func getFileExtensionFromUrl(rawUrl string) (string, error) {
 	return u.Path[pos+1:], nil
 }
 
-func GenerateStreamURL(baseUrl string, title string, sampleUrl string) string {
+func GenerateStreamURL(baseUrl string, slug string, sampleUrl string) string {
 	ext, err := getFileExtensionFromUrl(sampleUrl)
 	if err != nil {
-		return fmt.Sprintf("%s/%s\n", baseUrl, utils.GetStreamUID(title))
+		return fmt.Sprintf("%s/%s\n", baseUrl, utils.GetStreamUrl(slug))
 	}
-	return fmt.Sprintf("%s/%s.%s\n", baseUrl, utils.GetStreamUID(title), ext)
+	return fmt.Sprintf("%s/%s.%s\n", baseUrl, utils.GetStreamUrl(slug), ext)
 }
 
 func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Instance) {
@@ -65,7 +65,7 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 		}
 
 		// Write stream URL
-		_, err = fmt.Fprintf(w, "%s", GenerateStreamURL(baseUrl, stream.Title, stream.URLs[0].Content))
+		_, err = fmt.Fprintf(w, "%s", GenerateStreamURL(baseUrl, stream.Slug, stream.URLs[0].Content))
 		if err != nil {
 			continue
 		}

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -35,12 +35,7 @@ func TestGenerateM3UContent(t *testing.T) {
 		t.Errorf("ClearDb returned error: %v", err)
 	}
 
-	err = db.InsertStream(stream)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = db.InsertStreamUrl(stream, stream.URLs[0])
+	err = db.SaveToDb([]database.StreamInfo{stream})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -12,6 +12,7 @@ import (
 func TestGenerateM3UContent(t *testing.T) {
 	// Define a sample stream for testing
 	stream := database.StreamInfo{
+		Slug:    "test-stream",
 		TvgID:   "1",
 		Title:   "TestStream",
 		LogoURL: "http://example.com/logo.png",
@@ -75,7 +76,7 @@ func TestGenerateM3UContent(t *testing.T) {
 	// Check the generated M3U content
 	expectedContent := fmt.Sprintf(`#EXTM3U
 #EXTINF:-1 channelID="x-ID.1" tvg-chno="" tvg-id="1" tvg-name="TestStream" tvg-logo="http://example.com/logo.png" group-title="TestGroup",TestStream
-%s`, GenerateStreamURL("http:///stream", "TestStream", stream.URLs[0].Content))
+%s`, GenerateStreamURL("http:///stream", "test-stream", stream.URLs[0].Content))
 	if rr.Body.String() != expectedContent {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expectedContent)
@@ -125,22 +126,22 @@ http://example.com/fox
 
 	// Verify expected values
 	expectedStreams := []database.StreamInfo{
-		{Title: "BBC One", TvgChNo: "0.0", TvgID: "bbc1", Group: "UK", URLs: []database.StreamURL{
+		{Slug: "bbc-one", Title: "BBC One", TvgChNo: "0.0", TvgID: "bbc1", Group: "UK", URLs: []database.StreamURL{
 			{
 				Content: "http://example.com/bbc1",
 			},
 		}},
-		{Title: "BBC Two", TvgChNo: "0.0", TvgID: "bbc2", Group: "UK", URLs: []database.StreamURL{
+		{Slug: "bbc-two", Title: "BBC Two", TvgChNo: "0.0", TvgID: "bbc2", Group: "UK", URLs: []database.StreamURL{
 			{
 				Content: "http://example.com/bbc2",
 			},
 		}},
-		{Title: "CNN International", TvgChNo: "0.0", TvgID: "cnn", Group: "News", URLs: []database.StreamURL{
+		{Slug: "cnn-international", Title: "CNN International", TvgChNo: "0.0", TvgID: "cnn", Group: "News", URLs: []database.StreamURL{
 			{
 				Content: "http://example.com/cnn",
 			},
 		}},
-		{Title: "FOX", TvgChNo: "0.0", Group: "Entertainment", URLs: []database.StreamURL{
+		{Slug: "fox", Title: "FOX", TvgChNo: "0.0", Group: "Entertainment", URLs: []database.StreamURL{
 			{
 				Content: "http://example.com/fox",
 			},
@@ -178,7 +179,7 @@ http://example.com/fox
 
 // streamInfoEqual checks if two StreamInfo objects are equal.
 func streamInfoEqual(a, b database.StreamInfo) bool {
-	if a.TvgID != b.TvgID || a.TvgChNo != b.TvgChNo || a.Title != b.Title || a.Group != b.Group || a.LogoURL != b.LogoURL || len(a.URLs) != len(b.URLs) {
+	if a.Slug != b.Slug || a.TvgID != b.TvgID || a.TvgChNo != b.TvgChNo || a.Title != b.Title || a.Group != b.Group || a.LogoURL != b.LogoURL || len(a.URLs) != len(b.URLs) {
 		return false
 	}
 

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -29,7 +29,8 @@ func parseLine(line string, nextLine string, m3uIndex int) database.StreamInfo {
 	lineWithoutPairs := line
 
 	// Define a regular expression to capture key-value pairs
-	regex := regexp.MustCompile(`([a-zA-Z0-9_-]+)=("[^"]+"|[^",]+)`)
+	// regex := regexp.MustCompile(`([a-zA-Z0-9_-]+)=("[^"]+"|[^",]+)`)
+	regex := regexp.MustCompile(`([a-zA-Z0-9_-]+)="([^"]+)"`)
 
 	// Find all key-value pairs in the line
 	matches := regex.FindAllStringSubmatch(line, -1)

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -15,6 +15,8 @@ import (
 
 	"m3u-stream-merger/database"
 	"m3u-stream-merger/utils"
+
+	"github.com/gosimple/slug"
 )
 
 func parseLine(line string, nextLine string, m3uIndex int) database.StreamInfo {
@@ -61,6 +63,8 @@ func parseLine(line string, nextLine string, m3uIndex int) database.StreamInfo {
 	if len(lineCommaSplit) > 1 {
 		currentStream.Title = tvgNameParser(strings.TrimSpace(lineCommaSplit[1]))
 	}
+
+	currentStream.Slug = slug.Make(currentStream.Title)
 
 	return currentStream
 }

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -187,6 +187,7 @@ func ParseM3UFromURL(db *database.Instance, m3uURL string, m3uIndex int) error {
 			return fmt.Errorf("scanner error: %v", err)
 		}
 
+		log.Printf("%v", streams)
 		if err := db.SaveToDb(streams); err != nil {
 			log.Printf("M3U Parser error: %v", err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -62,7 +62,7 @@ func TestStreamHandler(t *testing.T) {
 		go func(stream database.StreamInfo) {
 			defer wg.Done()
 			log.Printf("Stream (%s): %v", stream.Title, stream)
-			req := httptest.NewRequest("GET", strings.TrimSpace(m3u.GenerateStreamURL("", stream.Title, stream.URLs[0].Content)), nil)
+			req := httptest.NewRequest("GET", strings.TrimSpace(m3u.GenerateStreamURL("", stream.Slug, stream.URLs[0].Content)), nil)
 			w := httptest.NewRecorder()
 
 			// Call the handler function

--- a/utils/url.go
+++ b/utils/url.go
@@ -2,11 +2,11 @@ package utils
 
 import "encoding/base64"
 
-func GetStreamUID(streamName string) string {
-	return base64.URLEncoding.EncodeToString([]byte(streamName))
+func GetStreamUrl(slug string) string {
+	return base64.URLEncoding.EncodeToString([]byte(slug))
 }
 
-func GetStreamName(streamUID string) string {
+func GetStreamSlugFromUrl(streamUID string) string {
 	decoded, err := base64.URLEncoding.DecodeString(streamUID)
 	if err != nil {
 		return ""

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -4,47 +4,47 @@ import (
 	"testing"
 )
 
-func TestGetStreamUID(t *testing.T) {
+func TestGetStreamUrl(t *testing.T) {
 	testCases := []struct {
-		streamName string
-		expected   string
+		slug     string
+		expected string
 	}{
-		{"testStreamName", "dGVzdFN0cmVhbU5hbWU="},
+		{"test-stream-name", "dGVzdC1zdHJlYW0tbmFtZQ=="},
 		// Add more test cases as needed
 	}
 
 	for _, tc := range testCases {
-		actual := GetStreamUID(tc.streamName)
+		actual := GetStreamUrl(tc.slug)
 		if actual != tc.expected {
-			t.Errorf("GetStreamUID(%s) = %s; expected %s", tc.streamName, actual, tc.expected)
+			t.Errorf("GetStreamUrl(%s) = %s; expected %s", tc.slug, actual, tc.expected)
 		}
 	}
 }
 
-func TestGetStreamName(t *testing.T) {
+func TestGetStreamSlugFromUrl(t *testing.T) {
 	testCases := []struct {
 		streamUID string
 		expected  string
 	}{
-		{"dGVzdFN0cmVhbU5hbWU=", "testStreamName"},
+		{"dGVzdC1zdHJlYW0tbmFtZQ==", "test-stream-name"},
 		// Add more test cases as needed
 	}
 
 	for _, tc := range testCases {
-		actual := GetStreamName(tc.streamUID)
+		actual := GetStreamSlugFromUrl(tc.streamUID)
 		if actual != tc.expected {
-			t.Errorf("GetStreamName(%s) = %s; expected %s", tc.streamUID, actual, tc.expected)
+			t.Errorf("GetStreamSlugFromUrl(%s) = %s; expected %s", tc.streamUID, actual, tc.expected)
 		}
 	}
 }
 
-func TestGetStreamName_ErrorCase(t *testing.T) {
+func TestGetStreamSlugFromUrl_ErrorCase(t *testing.T) {
 	// Test case for error handling when decoding fails
 	invalidStreamUID := "invalidBase64"
 	expected := ""
 
-	actual := GetStreamName(invalidStreamUID)
+	actual := GetStreamSlugFromUrl(invalidStreamUID)
 	if actual != expected {
-		t.Errorf("GetStreamName(%s) = %s; expected %s", invalidStreamUID, actual, expected)
+		t.Errorf("GetStreamSlugFromUrl(%s) = %s; expected %s", invalidStreamUID, actual, expected)
 	}
 }


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Since redis uses colons ":" as a "special" character for keys, slugifying the title to be used is needed.
* High resource usage was observed on large M3Us especially on query and insert.
* For M3U parsing, assume proper format and all values of tags are within double quotation marks.

## Choices

* Use pipelines for Redis queries.
* Slugify stream titles

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.