### PR TITLE
Use map for m3u index instead of an array

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -27,20 +27,14 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 		TvgID:   "test1",
 		LogoURL: "http://test.com/image.png",
 		Group:   "test",
-		URLs: []StreamURL{{
-			Content:  "testing",
-			M3UIndex: 1,
-		}},
+		URLs:    map[int]string{0: "testing"},
 	}, {
 		Slug:    "stream2",
 		Title:   "stream2",
 		TvgID:   "test2",
 		LogoURL: "http://test2.com/image.png",
 		Group:   "test2",
-		URLs: []StreamURL{{
-			Content:  "testing2",
-			M3UIndex: 2,
-		}},
+		URLs:    map[int]string{0: "testing2"},
 	}}
 
 	err = db.SaveToDb(expected) // Insert test data into the database
@@ -68,7 +62,7 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 		t.Errorf("DeleteStreamBySlug returned error: %v", err)
 	}
 
-	err = db.DeleteStreamURL(expected[0], expected[0].URLs[0].M3UIndex)
+	err = db.DeleteStreamURL(expected[0], 0)
 	if err != nil {
 		t.Errorf("DeleteStreamURL returned error: %v", err)
 	}
@@ -79,7 +73,7 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 	}
 
 	expected = expected[:1]
-	expected[0].URLs = make([]StreamURL, 0)
+	expected[0].URLs = map[int]string{}
 
 	if len(result) != len(expected) {
 		t.Errorf("GetStreams returned %+v, expected %+v", result, expected)
@@ -100,7 +94,7 @@ func streamInfoEqual(a, b StreamInfo) bool {
 	}
 
 	for i, url := range a.URLs {
-		if url.Content != b.URLs[i].Content || url.M3UIndex != b.URLs[i].M3UIndex {
+		if url != b.URLs[i] {
 			return false
 		}
 	}

--- a/database/db.go
+++ b/database/db.go
@@ -148,6 +148,7 @@ func (db *Instance) GetStreamBySlug(slug string) (StreamInfo, error) {
 		TvgChNo: streamData["tvg_chno"],
 		LogoURL: streamData["logo_url"],
 		Group:   streamData["group_name"],
+		URLs:    map[int]string{},
 	}
 
 	cursor := uint64(0)
@@ -234,6 +235,7 @@ func (db *Instance) GetStreams() ([]StreamInfo, error) {
 			TvgChNo: streamData["tvg_chno"],
 			LogoURL: streamData["logo_url"],
 			Group:   streamData["group_name"],
+			URLs:    map[int]string{},
 		}
 
 		urlKeys, err := db.Redis.Keys(db.Ctx, fmt.Sprintf("%s:url:*", streamKeys[i])).Result()

--- a/database/types.go
+++ b/database/types.go
@@ -7,10 +7,5 @@ type StreamInfo struct {
 	TvgChNo string
 	LogoURL string
 	Group   string
-	URLs    []StreamURL
-}
-
-type StreamURL struct {
-	Content  string
-	M3UIndex int
+	URLs    map[int]string
 }

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -65,7 +65,7 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 		}
 
 		// Write stream URL
-		_, err = fmt.Fprintf(w, "%s", GenerateStreamURL(baseUrl, stream.Slug, stream.URLs[0].Content))
+		_, err = fmt.Fprintf(w, "%s", GenerateStreamURL(baseUrl, stream.Slug, stream.URLs[0]))
 		if err != nil {
 			continue
 		}

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -17,7 +17,7 @@ func TestGenerateM3UContent(t *testing.T) {
 		Title:   "TestStream",
 		LogoURL: "http://example.com/logo.png",
 		Group:   "TestGroup",
-		URLs:    []database.StreamURL{{Content: "http://example.com/stream"}},
+		URLs:    map[int]string{0: "http://example.com/stream"},
 	}
 
 	// Test InitializeSQLite and check if the database file exists
@@ -71,7 +71,7 @@ func TestGenerateM3UContent(t *testing.T) {
 	// Check the generated M3U content
 	expectedContent := fmt.Sprintf(`#EXTM3U
 #EXTINF:-1 channelID="x-ID.1" tvg-chno="" tvg-id="1" tvg-name="TestStream" tvg-logo="http://example.com/logo.png" group-title="TestGroup",TestStream
-%s`, GenerateStreamURL("http:///stream", "test-stream", stream.URLs[0].Content))
+%s`, GenerateStreamURL("http:///stream", "test-stream", stream.URLs[0]))
 	if rr.Body.String() != expectedContent {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expectedContent)
@@ -121,26 +121,10 @@ http://example.com/fox
 
 	// Verify expected values
 	expectedStreams := []database.StreamInfo{
-		{Slug: "bbc-one", Title: "BBC One", TvgChNo: "0.0", TvgID: "bbc1", Group: "UK", URLs: []database.StreamURL{
-			{
-				Content: "http://example.com/bbc1",
-			},
-		}},
-		{Slug: "bbc-two", Title: "BBC Two", TvgChNo: "0.0", TvgID: "bbc2", Group: "UK", URLs: []database.StreamURL{
-			{
-				Content: "http://example.com/bbc2",
-			},
-		}},
-		{Slug: "cnn-international", Title: "CNN International", TvgChNo: "0.0", TvgID: "cnn", Group: "News", URLs: []database.StreamURL{
-			{
-				Content: "http://example.com/cnn",
-			},
-		}},
-		{Slug: "fox", Title: "FOX", TvgChNo: "0.0", Group: "Entertainment", URLs: []database.StreamURL{
-			{
-				Content: "http://example.com/fox",
-			},
-		}},
+		{Slug: "bbc-one", Title: "BBC One", TvgChNo: "0.0", TvgID: "bbc1", Group: "UK", URLs: map[int]string{0: "http://example.com/bbc1"}},
+		{Slug: "bbc-two", Title: "BBC Two", TvgChNo: "0.0", TvgID: "bbc2", Group: "UK", URLs: map[int]string{0: "http://example.com/bbc2"}},
+		{Slug: "cnn-international", Title: "CNN International", TvgChNo: "0.0", TvgID: "cnn", Group: "News", URLs: map[int]string{0: "http://example.com/cnn"}},
+		{Slug: "fox", Title: "FOX", TvgChNo: "0.0", Group: "Entertainment", URLs: map[int]string{0: "http://example.com/fox"}},
 	}
 
 	storedStreams, err := db.GetStreams()
@@ -179,7 +163,7 @@ func streamInfoEqual(a, b database.StreamInfo) bool {
 	}
 
 	for i, url := range a.URLs {
-		if url.Content != b.URLs[i].Content || url.M3UIndex != b.URLs[i].M3UIndex {
+		if url != b.URLs[i] {
 			return false
 		}
 	}

--- a/m3u/parser.go
+++ b/m3u/parser.go
@@ -21,10 +21,7 @@ import (
 
 func parseLine(line string, nextLine string, m3uIndex int) database.StreamInfo {
 	var currentStream database.StreamInfo
-	currentStream.URLs = []database.StreamURL{{
-		Content:  strings.TrimSpace(nextLine),
-		M3UIndex: m3uIndex,
-	}}
+	currentStream.URLs = map[int]string{m3uIndex: strings.TrimSpace(nextLine)}
 
 	lineWithoutPairs := line
 

--- a/main_test.go
+++ b/main_test.go
@@ -62,7 +62,7 @@ func TestStreamHandler(t *testing.T) {
 		go func(stream database.StreamInfo) {
 			defer wg.Done()
 			log.Printf("Stream (%s): %v", stream.Title, stream)
-			req := httptest.NewRequest("GET", strings.TrimSpace(m3u.GenerateStreamURL("", stream.Slug, stream.URLs[0].Content)), nil)
+			req := httptest.NewRequest("GET", strings.TrimSpace(m3u.GenerateStreamURL("", stream.Slug, stream.URLs[0])), nil)
 			w := httptest.NewRecorder()
 
 			// Call the handler function
@@ -74,7 +74,7 @@ func TestStreamHandler(t *testing.T) {
 				t.Errorf("%s - Expected status code %d, got %d", stream.Title, http.StatusOK, resp.StatusCode)
 			}
 
-			res, err := http.Get(stream.URLs[0].Content)
+			res, err := http.Get(stream.URLs[0])
 			if err != nil {
 				t.Errorf("HttpGet returned error: %v", err)
 			}

--- a/stream_handler.go
+++ b/stream_handler.go
@@ -15,13 +15,7 @@ import (
 )
 
 func loadBalancer(stream database.StreamInfo, previous int) (*http.Response, string, int, error) {
-	m3uIndexes := make([]int, 0, len(stream.URLs))
-	for k := range stream.URLs {
-		if k == previous {
-			continue
-		}
-		m3uIndexes = append(m3uIndexes, k)
-	}
+	m3uIndexes := utils.GetM3UIndexes()
 
 	sort.Slice(m3uIndexes, func(i, j int) bool {
 		return db.ConcurrencyPriorityValue(i) > db.ConcurrencyPriorityValue(j)
@@ -34,10 +28,19 @@ func loadBalancer(stream database.StreamInfo, previous int) (*http.Response, str
 		allSkipped := true // Assume all URLs might be skipped
 
 		for _, index := range m3uIndexes {
-			url := stream.URLs[index]
+			if index == previous {
+				log.Printf("Skipping M3U_%d: marked as previous stream\n", index+1)
+				continue
+			}
+
+			url, ok := stream.URLs[index]
+			if !ok {
+				log.Printf("Channel not found from M3U_%d: %s\n", index+1, stream.Title)
+				continue
+			}
 
 			if db.CheckConcurrency(index) {
-				log.Printf("Concurrency limit reached for M3U_%d: %s", index+1, url)
+				log.Printf("Concurrency limit reached for M3U_%d: %s\n", index+1, url)
 				continue
 			}
 
@@ -51,7 +54,7 @@ func loadBalancer(stream database.StreamInfo, previous int) (*http.Response, str
 		}
 
 		if allSkipped {
-			break // Break early if all URLs are skipped due to concurrency
+			break
 		}
 
 		lap++
@@ -126,55 +129,55 @@ func streamHandler(w http.ResponseWriter, r *http.Request, db *database.Instance
 		return
 	}
 
-	resp, selectedUrl, selectedIndex, err := loadBalancer(stream, -1)
-	if err != nil {
-		log.Printf("Error fetching initial stream for %s: %v\n", streamSlug, err)
-		http.Error(w, "Error fetching stream. Exhausted all streams.", http.StatusInternalServerError)
-		return
-	}
-
-	for k, v := range resp.Header {
-		if strings.ToLower(k) != "content-length" {
-			for _, val := range v {
-				w.Header().Set(k, val)
-			}
-		}
-	}
-
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	currentIndex := -1
+	var resp *http.Response
 
 	for {
 		select {
 		case <-ctx.Done():
 			log.Printf("Client disconnected: %s\n", r.RemoteAddr)
-			resp.Body.Close()
+			if resp != nil {
+				resp.Body.Close()
+			}
 			return
 		default:
+			var selectedUrl string
+			var selectedIndex int
+
+			resp, selectedUrl, selectedIndex, err = loadBalancer(stream, currentIndex)
+			if err != nil {
+				log.Printf("Error reloading stream for %s: %v\n", streamSlug, err)
+				http.Error(w, "Error fetching stream. Exhausted all streams.", http.StatusInternalServerError)
+				return
+			}
+
+			// HTTP header initialization
+			if currentIndex == -1 {
+				w.Header().Set("Cache-Control", "no-cache")
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+				for k, v := range resp.Header {
+					if strings.ToLower(k) != "content-length" {
+						for _, val := range v {
+							w.Header().Set(k, val)
+						}
+					}
+				}
+			}
 			exitStatus := make(chan int)
 
-			currentUrl := selectedUrl
-			currentIndex := selectedIndex
-			currentResp := resp
+			currentIndex = selectedIndex
 
-			log.Printf("Proxying %s to %s\n", r.RemoteAddr, currentUrl)
+			log.Printf("Proxying %s to %s\n", r.RemoteAddr, selectedUrl)
 			go func(m3uIndex int, resp *http.Response, r *http.Request, w http.ResponseWriter, exitStatus chan int) {
 				proxyStream(m3uIndex, resp, r, w, exitStatus)
-			}(currentIndex, currentResp, r, w, exitStatus)
+			}(currentIndex, resp, r, w, exitStatus)
 
 			streamExitCode := <-exitStatus
-			log.Printf("Exit code %d received from %s\n", streamExitCode, currentUrl)
+			log.Printf("Exit code %d received from %s\n", streamExitCode, selectedUrl)
 
 			if streamExitCode == 1 {
 				// Retry on server-side connection errors
-				log.Printf("Server connection failed: %s\n", currentUrl)
 				log.Printf("Retrying other servers...\n")
-				resp, selectedUrl, selectedIndex, err = loadBalancer(stream, currentIndex)
-				if err != nil {
-					log.Printf("Error reloading stream for %s: %v\n", streamSlug, err)
-					http.Error(w, "Error fetching stream. Exhausted all streams.", http.StatusInternalServerError)
-					return
-				}
 			} else {
 				// Consider client-side connection errors as complete closure
 				log.Printf("Client has closed the stream: %s\n", r.RemoteAddr)

--- a/utils/env.go
+++ b/utils/env.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"os"
+	"strconv"
+	"strings"
 )
 
 func GetEnv(env string) string {
@@ -16,4 +18,20 @@ func GetEnv(env string) string {
 	default:
 		return ""
 	}
+}
+
+func GetM3UIndexes() []int {
+	m3uIndexes := []int{}
+	for _, env := range os.Environ() {
+		pair := strings.SplitN(env, "=", 2)
+		if strings.HasPrefix(pair[0], "M3U_URL_") {
+			indexString := strings.TrimPrefix(pair[0], "M3U_URL_")
+			index, err := strconv.Atoi(indexString)
+			if err != nil {
+				continue
+			}
+			m3uIndexes = append(m3uIndexes, index)
+		}
+	}
+	return m3uIndexes
 }


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Using the index number used in env var configs directly would be much easier for the load balancer
* The usage of an array was initially designed due to the use of SQLite rather than a KV database like Redis.

## Choices

* Simplify StreamURL data structure to map[int]string.

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.