### PR TITLE
Use channels for streams and remove chunking on M3U generation

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -42,9 +42,33 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 		t.Errorf("SaveToDb returned error: %v", err)
 	}
 
-	result, err := db.GetStreams()
-	if err != nil {
-		t.Errorf("GetStreams returned error: %v", err)
+	streamChan, errChan := db.GetStreams()
+
+	var result []StreamInfo
+	for {
+		select {
+		case stream, ok := <-streamChan:
+			if !ok {
+				streamChan = nil // Close the channel when done
+				break
+			}
+
+			result = append(result, stream)
+
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil // Close the channel when done
+				break
+			}
+			if err != nil {
+				t.Errorf("GetStreams returned error: %v", err)
+			}
+		}
+
+		// Exit the loop when both channels are closed
+		if streamChan == nil && errChan == nil {
+			break
+		}
 	}
 
 	if len(result) != len(expected) {
@@ -67,9 +91,33 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 		t.Errorf("DeleteStreamURL returned error: %v", err)
 	}
 
-	result, err = db.GetStreams()
-	if err != nil {
-		t.Errorf("GetStreams returned error: %v", err)
+	streamChan, errChan = db.GetStreams()
+
+	result = []StreamInfo{}
+	for {
+		select {
+		case stream, ok := <-streamChan:
+			if !ok {
+				streamChan = nil // Close the channel when done
+				break
+			}
+
+			result = append(result, stream)
+
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil // Close the channel when done
+				break
+			}
+			if err != nil {
+				t.Errorf("GetStreams returned error: %v", err)
+			}
+		}
+
+		// Exit the loop when both channels are closed
+		if streamChan == nil && errChan == nil {
+			break
+		}
 	}
 
 	expected = expected[:1]

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -42,33 +42,11 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 		t.Errorf("SaveToDb returned error: %v", err)
 	}
 
-	streamChan, errChan := db.GetStreams()
+	streamChan := db.GetStreams()
 
 	var result []StreamInfo
-	for {
-		select {
-		case stream, ok := <-streamChan:
-			if !ok {
-				streamChan = nil // Close the channel when done
-				break
-			}
-
-			result = append(result, stream)
-
-		case err, ok := <-errChan:
-			if !ok {
-				errChan = nil // Close the channel when done
-				break
-			}
-			if err != nil {
-				t.Errorf("GetStreams returned error: %v", err)
-			}
-		}
-
-		// Exit the loop when both channels are closed
-		if streamChan == nil && errChan == nil {
-			break
-		}
+	for stream := range streamChan {
+		result = append(result, stream)
 	}
 
 	if len(result) != len(expected) {
@@ -91,33 +69,11 @@ func TestSaveAndLoadFromDb(t *testing.T) {
 		t.Errorf("DeleteStreamURL returned error: %v", err)
 	}
 
-	streamChan, errChan = db.GetStreams()
+	streamChan = db.GetStreams()
 
 	result = []StreamInfo{}
-	for {
-		select {
-		case stream, ok := <-streamChan:
-			if !ok {
-				streamChan = nil // Close the channel when done
-				break
-			}
-
-			result = append(result, stream)
-
-		case err, ok := <-errChan:
-			if !ok {
-				errChan = nil // Close the channel when done
-				break
-			}
-			if err != nil {
-				t.Errorf("GetStreams returned error: %v", err)
-			}
-		}
-
-		// Exit the loop when both channels are closed
-		if streamChan == nil && errChan == nil {
-			break
-		}
+	for stream := range streamChan {
+		result = append(result, stream)
 	}
 
 	expected = expected[:1]

--- a/m3u/generate.go
+++ b/m3u/generate.go
@@ -83,7 +83,7 @@ func GenerateM3UContent(w http.ResponseWriter, r *http.Request, db *database.Ins
 		}
 
 		// Write the actual stream URL to the response
-		_, err = fmt.Fprintf(w, "%s\n", GenerateStreamURL(baseUrl, stream.Slug, stream.URLs[0]))
+		_, err = fmt.Fprintf(w, "%s", GenerateStreamURL(baseUrl, stream.Slug, stream.URLs[0]))
 		if err != nil {
 			if debug {
 				log.Printf("[DEBUG] Error writing stream URL for stream %s: %v\n", stream.TvgID, err)

--- a/m3u/m3u_test.go
+++ b/m3u/m3u_test.go
@@ -141,33 +141,11 @@ http://example.com/fox
 		{Slug: "fox", Title: "FOX", TvgChNo: "0.0", Group: "Entertainment", URLs: map[int]string{0: "http://example.com/fox", 1: "http://example.com/fox"}},
 	}
 
-	streamChan, errChan := db.GetStreams()
+	streamChan := db.GetStreams()
 
 	storedStreams := []database.StreamInfo{}
-	for {
-		select {
-		case stream, ok := <-streamChan:
-			if !ok {
-				streamChan = nil // Close the channel when done
-				break
-			}
-
-			storedStreams = append(storedStreams, stream)
-
-		case err, ok := <-errChan:
-			if !ok {
-				errChan = nil // Close the channel when done
-				break
-			}
-			if err != nil {
-				t.Fatalf("Error retrieving streams from database: %v", err)
-			}
-		}
-
-		// Exit the loop when both channels are closed
-		if streamChan == nil && errChan == nil {
-			break
-		}
+	for stream := range streamChan {
+		storedStreams = append(storedStreams, stream)
 	}
 
 	// Compare the retrieved streams with the expected streams

--- a/main.go
+++ b/main.go
@@ -119,16 +119,7 @@ func main() {
 		if cacheOnSync == "true" {
 			wg.Wait()
 			log.Println("CACHE_ON_SYNC enabled. Building cache.")
-			cacheErr := make(chan error)
-			go func(db *database.Instance) {
-				_, err := db.GetStreams()
-				cacheErr <- <-err
-			}(db)
-			go func() {
-				if <-cacheErr != nil {
-					log.Printf("CACHE_ON_SYNC error: %v\n", err)
-				}
-			}()
+			db.GetStreams()
 		}
 	})
 	if err != nil {
@@ -151,16 +142,7 @@ func main() {
 		if cacheOnSync == "true" {
 			wg.Wait()
 			log.Println("CACHE_ON_SYNC enabled. Building cache.")
-			cacheErr := make(chan error)
-			go func(db *database.Instance) {
-				_, err := db.GetStreams()
-				cacheErr <- <-err
-			}(db)
-			go func() {
-				if <-cacheErr != nil {
-					log.Printf("CACHE_ON_SYNC error: %v\n", err)
-				}
-			}()
+			db.GetStreams()
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 			cacheErr := make(chan error)
 			go func(db *database.Instance) {
 				_, err := db.GetStreams()
-				cacheErr <- err
+				cacheErr <- <-err
 			}(db)
 			go func() {
 				if <-cacheErr != nil {
@@ -154,7 +154,7 @@ func main() {
 			cacheErr := make(chan error)
 			go func(db *database.Instance) {
 				_, err := db.GetStreams()
-				cacheErr <- err
+				cacheErr <- <-err
 			}(db)
 			go func() {
 				if <-cacheErr != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -39,9 +39,32 @@ func TestStreamHandler(t *testing.T) {
 
 	updateSources(ctx, nil)
 
-	streams, err := db.GetStreams()
-	if err != nil {
-		t.Errorf("GetStreams returned error: %v", err)
+	streamChan, errChan := db.GetStreams()
+	streams := []database.StreamInfo{}
+	for {
+		select {
+		case stream, ok := <-streamChan:
+			if !ok {
+				streamChan = nil // Close the channel when done
+				break
+			}
+
+			streams = append(streams, stream)
+
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil // Close the channel when done
+				break
+			}
+			if err != nil {
+				t.Errorf("GetStreams returned error: %v", err)
+			}
+		}
+
+		// Exit the loop when both channels are closed
+		if streamChan == nil && errChan == nil {
+			break
+		}
 	}
 
 	m3uReq := httptest.NewRequest("GET", "/playlist.m3u", nil)

--- a/main_test.go
+++ b/main_test.go
@@ -39,32 +39,11 @@ func TestStreamHandler(t *testing.T) {
 
 	updateSources(ctx, nil)
 
-	streamChan, errChan := db.GetStreams()
+	streamChan := db.GetStreams()
 	streams := []database.StreamInfo{}
-	for {
-		select {
-		case stream, ok := <-streamChan:
-			if !ok {
-				streamChan = nil // Close the channel when done
-				break
-			}
 
-			streams = append(streams, stream)
-
-		case err, ok := <-errChan:
-			if !ok {
-				errChan = nil // Close the channel when done
-				break
-			}
-			if err != nil {
-				t.Errorf("GetStreams returned error: %v", err)
-			}
-		}
-
-		// Exit the loop when both channels are closed
-		if streamChan == nil && errChan == nil {
-			break
-		}
+	for stream := range streamChan {
+		streams = append(streams, stream)
 	}
 
 	m3uReq := httptest.NewRequest("GET", "/playlist.m3u", nil)


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Chunking and parallelizing an array of streams from Redis breaks the sort order

## Choices

* <!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.