### PR TITLE
Add zero padding on integer/float tvg-id or tvg-chno values to fix sorting

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -384,14 +384,23 @@ func extractM3UIndex(key string) string {
 func getSortingValue(s StreamInfo) string {
 	key := os.Getenv("SORTING_KEY")
 
+	var value string
 	switch key {
 	case "tvg-id":
-		return s.TvgID + s.Title
+		value = s.TvgID
 	case "tvg-chno":
-		return s.TvgChNo + s.Title
+		value = s.TvgChNo
+	default:
+		value = s.TvgID
 	}
 
-	return s.TvgID + s.Title
+	// Try to parse the value as a float.
+	if numValue, err := strconv.ParseFloat(value, 64); err == nil {
+		return fmt.Sprintf("%010.2f", numValue) // Fixed-width string with zero-padding and 2 decimal places
+	}
+
+	// If parsing fails, fall back to using the original string value.
+	return value + s.Title
 }
 
 func calculateSortScore(s StreamInfo) float64 {

--- a/database/db.go
+++ b/database/db.go
@@ -396,7 +396,7 @@ func getSortingValue(s StreamInfo) string {
 
 	// Try to parse the value as a float.
 	if numValue, err := strconv.ParseFloat(value, 64); err == nil {
-		return fmt.Sprintf("%010.2f", numValue) // Fixed-width string with zero-padding and 2 decimal places
+		return fmt.Sprintf("%010.2f", numValue) + s.Title
 	}
 
 	// If parsing fails, fall back to using the original string value.
@@ -405,7 +405,7 @@ func getSortingValue(s StreamInfo) string {
 
 func calculateSortScore(s StreamInfo) float64 {
 	// Add to the sorted set with tvg_id as the score
-	maxLen := 20
+	maxLen := 40
 	base := float64(256)
 
 	// Normalize length by padding the string


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* <!-- What do you want to achieve with this PR? -->

## Choices

* <!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.