### PR TITLE
Prevent retry on EOF if mimetype is `application/x-mpegurl`

### DIFF
--- a/stream_handler.go
+++ b/stream_handler.go
@@ -140,7 +140,7 @@ func proxyStream(ctx context.Context, m3uIndex int, resp *http.Response, r *http
 			if err != nil {
 				if err == io.EOF {
 					log.Printf("Stream ended (EOF reached): %s\n", r.RemoteAddr)
-					if resp.Header.Get("Content-Type") != "video/mp2t" {
+					if strings.ToLower(resp.Header.Get("Content-Type")) != "video/mp2t" {
 						statusChan <- 2
 						return
 					}
@@ -283,7 +283,7 @@ func streamHandler(w http.ResponseWriter, r *http.Request, db *database.Instance
 			streamExitCode := <-exitStatus
 			log.Printf("Exit code %d received from %s\n", streamExitCode, selectedUrl)
 
-			if streamExitCode == 2 && resp.Header.Get("Content-Type") != "video/mp2t" {
+			if streamExitCode == 2 && strings.ToLower(resp.Header.Get("Content-Type")) != "video/mp2t" {
 				log.Printf("Successfully proxied file: %s\n", r.RemoteAddr)
 				cancel()
 			} else if streamExitCode == 1 || streamExitCode == 2 {

--- a/stream_handler.go
+++ b/stream_handler.go
@@ -140,7 +140,7 @@ func proxyStream(ctx context.Context, m3uIndex int, resp *http.Response, r *http
 			if err != nil {
 				if err == io.EOF {
 					log.Printf("Stream ended (EOF reached): %s\n", r.RemoteAddr)
-					if strings.ToLower(resp.Header.Get("Content-Type")) != "video/mp2t" {
+					if strings.ToLower(resp.Header.Get("Content-Type")) == "application/x-mpegurl" {
 						statusChan <- 2
 						return
 					}
@@ -283,8 +283,8 @@ func streamHandler(w http.ResponseWriter, r *http.Request, db *database.Instance
 			streamExitCode := <-exitStatus
 			log.Printf("Exit code %d received from %s\n", streamExitCode, selectedUrl)
 
-			if streamExitCode == 2 && strings.ToLower(resp.Header.Get("Content-Type")) != "video/mp2t" {
-				log.Printf("Successfully proxied file: %s\n", r.RemoteAddr)
+			if streamExitCode == 2 && strings.ToLower(resp.Header.Get("Content-Type")) == "application/x-mpegurl" {
+				log.Printf("Successfully proxied playlist: %s\n", r.RemoteAddr)
 				cancel()
 			} else if streamExitCode == 1 || streamExitCode == 2 {
 				// Retry on server-side connection errors

--- a/stream_handler.go
+++ b/stream_handler.go
@@ -140,7 +140,7 @@ func proxyStream(ctx context.Context, m3uIndex int, resp *http.Response, r *http
 			if err != nil {
 				if err == io.EOF {
 					log.Printf("Stream ended (EOF reached): %s\n", r.RemoteAddr)
-					if utils.IsPlaylistFile(r.RemoteAddr) {
+					if resp.Header.Get("Content-Type") != "video/mp2t" {
 						statusChan <- 2
 						return
 					}
@@ -283,8 +283,8 @@ func streamHandler(w http.ResponseWriter, r *http.Request, db *database.Instance
 			streamExitCode := <-exitStatus
 			log.Printf("Exit code %d received from %s\n", streamExitCode, selectedUrl)
 
-			if streamExitCode == 2 && utils.IsPlaylistFile(selectedUrl) {
-				log.Printf("Successfully proxied playlist (M3U) file: %s\n", r.RemoteAddr)
+			if streamExitCode == 2 && resp.Header.Get("Content-Type") != "video/mp2t" {
+				log.Printf("Successfully proxied file: %s\n", r.RemoteAddr)
 				cancel()
 			} else if streamExitCode == 1 || streamExitCode == 2 {
 				// Retry on server-side connection errors

--- a/utils/url.go
+++ b/utils/url.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"encoding/base64"
-	"strings"
 )
 
 func GetStreamUrl(slug string) string {
@@ -15,10 +14,4 @@ func GetStreamSlugFromUrl(streamUID string) string {
 		return ""
 	}
 	return string(decoded)
-}
-
-func IsPlaylistFile(url string) bool {
-	urlClean := strings.TrimSpace(strings.ToLower(url))
-
-	return strings.HasSuffix(urlClean, ".m3u") || strings.HasSuffix(urlClean, ".m3u8")
 }


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* 

## Choices

* <!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.