### PR TITLE
Convert relative urls from m3u8 streams to absolute paths on-the-fly

### DIFF
--- a/proxy/stream_handler.go
+++ b/proxy/stream_handler.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -8,6 +10,7 @@ import (
 	"m3u-stream-merger/database"
 	"m3u-stream-merger/utils"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"sort"
@@ -111,21 +114,6 @@ func (instance *StreamInstance) LoadBalancer(previous *[]int, method string) (*h
 
 func (instance *StreamInstance) ProxyStream(ctx context.Context, m3uIndex int, resp *http.Response, r *http.Request, w http.ResponseWriter, statusChan chan int) {
 	debug := os.Getenv("DEBUG") == "true"
-
-	if r.Method != http.MethodGet || utils.EOFIsExpected(resp) {
-		_, err := io.Copy(w, resp.Body)
-		statusChan <- 4
-
-		if err != nil {
-			log.Printf("Failed to write segment to response: %v", err)
-			return
-		}
-		return
-	}
-
-	instance.Database.UpdateConcurrency(m3uIndex, true)
-	defer instance.Database.UpdateConcurrency(m3uIndex, false)
-
 	bufferMbInt, err := strconv.Atoi(os.Getenv("BUFFER_MB"))
 	if err != nil || bufferMbInt < 0 {
 		bufferMbInt = 0
@@ -134,6 +122,60 @@ func (instance *StreamInstance) ProxyStream(ctx context.Context, m3uIndex int, r
 	if bufferMbInt > 0 {
 		buffer = make([]byte, bufferMbInt*1024*1024)
 	}
+
+	if r.Method != http.MethodGet || utils.EOFIsExpected(resp) {
+		tempBuffer := bytes.NewBuffer(buffer)
+		_, err := io.Copy(tempBuffer, resp.Body)
+		if err != nil {
+			log.Printf("Failed to write segment to tempBuffer: %v", err)
+			return
+		}
+
+		if utils.EOFIsExpected(resp) {
+			base, err := url.Parse(resp.Request.URL.String())
+			if err != nil {
+				log.Printf("Invalid base URL for M3U8 stream: %v", err)
+				return
+			}
+
+			var output bytes.Buffer
+			scanner := bufio.NewScanner(bytes.NewReader(tempBuffer.Bytes()))
+
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.HasPrefix(line, "#") {
+					output.WriteString(line + "\n")
+				} else if strings.TrimSpace(line) != "" {
+					u, err := url.Parse(line)
+					if err != nil {
+						log.Printf("Failed to parse M3U8 URL in line: %v", err)
+						continue
+					}
+
+					if !u.IsAbs() {
+						u = base.ResolveReference(u)
+					}
+
+					output.WriteString(u.String() + "\n")
+				}
+			}
+
+			tempBuffer = &output
+		}
+
+		_, err = io.Copy(w, tempBuffer)
+		if err != nil {
+			log.Printf("Failed to write tempBuffer to response: %v", err)
+			return
+		}
+
+		statusChan <- 4
+
+		return
+	}
+
+	instance.Database.UpdateConcurrency(m3uIndex, true)
+	defer instance.Database.UpdateConcurrency(m3uIndex, false)
 
 	defer func() {
 		buffer = nil

--- a/proxy/stream_handler.go
+++ b/proxy/stream_handler.go
@@ -124,7 +124,8 @@ func (instance *StreamInstance) ProxyStream(ctx context.Context, m3uIndex int, r
 	}
 
 	if r.Method != http.MethodGet || utils.EOFIsExpected(resp) {
-		content, err := io.ReadAll(resp.Body)
+		var content []byte
+		content, err = io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Error reading M3U8 stream content: %v", err)
 			return

--- a/proxy/stream_handler.go
+++ b/proxy/stream_handler.go
@@ -149,6 +149,7 @@ func (instance *StreamInstance) ProxyStream(ctx context.Context, m3uIndex int, r
 					u, err := url.Parse(line)
 					if err != nil {
 						log.Printf("Failed to parse M3U8 URL in line: %v", err)
+						output.WriteString(line + "\n")
 						continue
 					}
 

--- a/proxy/stream_handler.go
+++ b/proxy/stream_handler.go
@@ -125,6 +125,10 @@ func (instance *StreamInstance) ProxyStream(ctx context.Context, m3uIndex int, r
 
 	if r.Method != http.MethodGet || utils.EOFIsExpected(resp) {
 		content, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Error reading M3U8 stream content: %v", err)
+			return
+		}
 
 		if utils.EOFIsExpected(resp) {
 			if !bytes.HasPrefix(content, []byte("#EXTM3U\n")) {
@@ -330,7 +334,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			// HTTP header initialization
 			if firstWrite {
 				for k, v := range resp.Header {
-					if strings.ToLower(k) == "content-length" && !utils.EOFIsExpected(resp) {
+					if strings.ToLower(k) == "content-length" {
 						continue
 					}
 


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* #125 

## Choices

* <!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.