### PR TITLE
Add /v/* endpoint for proxying video streams inside M3U8 files

### DIFF
--- a/handlers/m3u_video_handler.go
+++ b/handlers/m3u_video_handler.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"m3u-stream-merger/proxy"
+	"m3u-stream-merger/utils"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+)
+
+func M3UVideoHandler(w http.ResponseWriter, r *http.Request) {
+	debug := os.Getenv("DEBUG") == "true"
+
+	ctx := r.Context()
+
+	utils.SafeLogf("Received request from %s for URL: %s\n", r.RemoteAddr, r.URL.Path)
+
+	streamUrl := strings.Split(path.Base(r.URL.Path), ".")[0]
+	if streamUrl == "" {
+		utils.SafeLogf("Invalid stream for request from %s: %s\n", r.RemoteAddr, r.URL.Path)
+		http.NotFound(w, r)
+		return
+	}
+
+	decodedStreamUrl, err := base64.URLEncoding.DecodeString(streamUrl)
+	if err != nil {
+		utils.SafeLogf("Error retrieving stream url %s: %v\n", streamUrl, err)
+		http.NotFound(w, r)
+		return
+	}
+
+	resp, err := utils.CustomHttpRequest(r.Method, string(decodedStreamUrl))
+	if err != nil {
+		utils.SafeLogf("Error fetching stream: %s\n", err.Error())
+	}
+	defer resp.Body.Close()
+
+	for k, v := range resp.Header {
+		if strings.ToLower(k) == "content-length" {
+			continue
+		}
+
+		for _, val := range v {
+			w.Header().Set(k, val)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	if debug {
+		utils.SafeLogf("[DEBUG] Headers set for response: %v\n", w.Header())
+	}
+
+	utils.SafeLogf("Proxying %s to %s\n", r.RemoteAddr, decodedStreamUrl)
+	proxyCtx, proxyCtxCancel := context.WithCancel(ctx)
+	defer proxyCtxCancel()
+
+	streamExitCode := proxy.ProxyVideoStream(proxyCtx, resp, r, w)
+	utils.SafeLogf("Exit code %d received from %s\n", streamExitCode, decodedStreamUrl)
+
+	if streamExitCode == 2 && utils.EOFIsExpected(resp) {
+		utils.SafeLogf("Successfully proxied playlist: %s\n", r.RemoteAddr)
+	} else if streamExitCode == 1 || streamExitCode == 2 {
+		// Retry on server-side connection errors
+		utils.SafeLogf("Server failed to respond: %s\n", decodedStreamUrl)
+	} else if streamExitCode == 4 {
+		utils.SafeLogf("Finished handling %s request: %s\n", r.Method, r.RemoteAddr)
+	} else {
+		// Consider client-side connection errors as complete closure
+		utils.SafeLogf("Unable to write to client. Assuming stream has been closed: %s\n", r.RemoteAddr)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,9 @@ func main() {
 	http.HandleFunc("/p/", func(w http.ResponseWriter, r *http.Request) {
 		handlers.StreamHandler(w, r, cm)
 	})
+	http.HandleFunc("/v/", func(w http.ResponseWriter, r *http.Request) {
+		handlers.M3UVideoHandler(w, r)
+	})
 
 	// Start the server
 	utils.SafeLogln(fmt.Sprintf("Server is running on port %s...", os.Getenv("PORT")))

--- a/proxy/proxy_stream.go
+++ b/proxy/proxy_stream.go
@@ -3,27 +3,18 @@ package proxy
 import (
 	"bufio"
 	"context"
-	"io"
+	"encoding/base64"
+	"fmt"
 	"m3u-stream-merger/utils"
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
+	"path"
 	"strings"
-	"time"
 )
 
 func (instance *StreamInstance) ProxyStream(ctx context.Context, m3uIndex string, subIndex string, resp *http.Response, r *http.Request, w http.ResponseWriter, statusChan chan int) {
 	debug := os.Getenv("DEBUG") == "true"
-
-	bufferMbInt, err := strconv.Atoi(os.Getenv("BUFFER_MB"))
-	if err != nil || bufferMbInt < 0 {
-		bufferMbInt = 0
-	}
-	buffer := make([]byte, 1024)
-	if bufferMbInt > 0 {
-		buffer = make([]byte, bufferMbInt*1024*1024)
-	}
 
 	if r.Method != http.MethodGet || utils.EOFIsExpected(resp) {
 		scanner := bufio.NewScanner(resp.Body)
@@ -60,7 +51,21 @@ func (instance *StreamInstance) ProxyStream(ctx context.Context, m3uIndex string
 					u = base.ResolveReference(u)
 				}
 
-				_, err = w.Write([]byte(u.String() + "\n"))
+				ext := ""
+				baseSplit := strings.Split(path.Base(r.URL.Path), ".")
+				if len(baseSplit) > 1 {
+					ext = baseSplit[len(baseSplit)-1]
+				}
+
+				origUrl := u.String()
+				encodedUrl := base64.URLEncoding.EncodeToString([]byte(origUrl))
+				newUrl := fmt.Sprintf("%s://%s/v/%s", r.URL.Scheme, r.URL.Host, encodedUrl)
+
+				if ext != "" {
+					newUrl += "." + ext
+				}
+
+				_, err = w.Write([]byte(newUrl + "\n"))
 				if err != nil {
 					utils.SafeLogf("Failed to write URL to response: %v", err)
 					statusChan <- 4
@@ -81,113 +86,5 @@ func (instance *StreamInstance) ProxyStream(ctx context.Context, m3uIndex string
 		instance.Cm.UpdateConcurrency(m3uIndex, false)
 	}()
 
-	defer func() {
-		buffer = nil
-	}()
-
-	timeoutSecond := 3
-	if ts, err := strconv.Atoi(os.Getenv("STREAM_TIMEOUT")); err == nil && ts >= 0 {
-		timeoutSecond = ts
-	}
-
-	timeoutDuration := time.Duration(timeoutSecond) * time.Second
-	if timeoutSecond == 0 {
-		timeoutDuration = time.Minute
-	}
-
-	timeStarted := time.Now()
-	lastErr := timeStarted
-
-	returnStatus := 0
-
-	// Backoff settings
-	initialBackoff := 200 * time.Millisecond
-	maxBackoff := time.Duration(timeoutSecond-1) * time.Second
-	currentBackoff := initialBackoff
-
-	contextSleep := func(ctx context.Context) {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(currentBackoff):
-			currentBackoff *= 2
-			if currentBackoff > maxBackoff {
-				currentBackoff = maxBackoff
-			}
-		}
-	}
-
-	readChan := make(chan struct {
-		n   int
-		err error
-	}, 1)
-
-	for {
-		go func() {
-			n, err := resp.Body.Read(buffer)
-			readChan <- struct {
-				n   int
-				err error
-			}{n, err}
-		}()
-
-		elapsed := time.Since(timeStarted)
-		if timeoutSecond > 0 && elapsed >= timeoutDuration {
-			utils.SafeLogf("Timeout reached while trying to stream: %s\n", r.RemoteAddr)
-			statusChan <- returnStatus
-			return
-		}
-
-		select {
-		case <-ctx.Done():
-			utils.SafeLogf("Context canceled for stream: %s\n", r.RemoteAddr)
-			_ = resp.Body.Close()
-			return
-		case result := <-readChan:
-			switch {
-			case result.err == io.EOF:
-				lastErr = time.Now()
-				if utils.EOFIsExpected(resp) || timeoutSecond == 0 {
-					utils.SafeLogf("Stream ended (expected EOF reached): %s\n", r.RemoteAddr)
-					statusChan <- 2
-					return
-				}
-
-				utils.SafeLogf("Stream ended (unexpected EOF reached): %s\n", r.RemoteAddr)
-				returnStatus = 2
-
-				utils.SafeLogf("Retrying same stream until timeout (%d seconds) is reached...\n", timeoutSecond)
-				contextSleep(ctx)
-			case result.err != nil:
-				lastErr = time.Now()
-				utils.SafeLogf("Error reading stream: %s\n", result.err.Error())
-				returnStatus = 1
-				if timeoutSecond == 0 {
-					statusChan <- 1
-					return
-				}
-
-				utils.SafeLogf("Retrying same stream until timeout (%d seconds) is reached...\n", timeoutSecond)
-				contextSleep(ctx)
-			case result.err == nil:
-				if _, err := w.Write(buffer[:result.n]); err != nil {
-					utils.SafeLogf("Error writing to response: %s\n", err.Error())
-					statusChan <- 0
-					return
-				}
-
-				if flusher, ok := w.(http.Flusher); ok {
-					flusher.Flush()
-				}
-
-				// check if never errored or last error was at least a second ago
-				if lastErr.Equal(timeStarted) || time.Since(lastErr) >= time.Second {
-					// Reset timer on successful read/write
-					timeStarted = time.Now()
-
-					currentBackoff = initialBackoff
-				}
-			}
-		}
-	}
+	statusChan <- ProxyVideoStream(ctx, resp, r, w)
 }

--- a/proxy/proxy_video_stream.go
+++ b/proxy/proxy_video_stream.go
@@ -1,0 +1,127 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"m3u-stream-merger/utils"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+func ProxyVideoStream(ctx context.Context, resp *http.Response, r *http.Request, w http.ResponseWriter) int {
+	bufferMbInt, err := strconv.Atoi(os.Getenv("BUFFER_MB"))
+	if err != nil || bufferMbInt < 0 {
+		bufferMbInt = 0
+	}
+	buffer := make([]byte, 1024)
+	if bufferMbInt > 0 {
+		buffer = make([]byte, bufferMbInt*1024*1024)
+	}
+	defer func() {
+		buffer = nil
+	}()
+
+	timeoutSecond := 3
+	if ts, err := strconv.Atoi(os.Getenv("STREAM_TIMEOUT")); err == nil && ts >= 0 {
+		timeoutSecond = ts
+	}
+
+	timeoutDuration := time.Duration(timeoutSecond) * time.Second
+	if timeoutSecond == 0 {
+		timeoutDuration = time.Minute
+	}
+
+	timeStarted := time.Now()
+	lastErr := timeStarted
+
+	returnStatus := 0
+
+	// Backoff settings
+	initialBackoff := 200 * time.Millisecond
+	maxBackoff := time.Duration(timeoutSecond-1) * time.Second
+	currentBackoff := initialBackoff
+
+	contextSleep := func(ctx context.Context) {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(currentBackoff):
+			currentBackoff *= 2
+			if currentBackoff > maxBackoff {
+				currentBackoff = maxBackoff
+			}
+		}
+	}
+
+	readChan := make(chan struct {
+		n   int
+		err error
+	}, 1)
+
+	for {
+		go func() {
+			n, err := resp.Body.Read(buffer)
+			readChan <- struct {
+				n   int
+				err error
+			}{n, err}
+		}()
+
+		elapsed := time.Since(timeStarted)
+		if timeoutSecond > 0 && elapsed >= timeoutDuration {
+			utils.SafeLogf("Timeout reached while trying to stream: %s\n", r.RemoteAddr)
+			return returnStatus
+		}
+
+		select {
+		case <-ctx.Done():
+			utils.SafeLogf("Context canceled for stream: %s\n", r.RemoteAddr)
+			_ = resp.Body.Close()
+			return 0
+		case result := <-readChan:
+			switch {
+			case result.err == io.EOF:
+				lastErr = time.Now()
+				if utils.EOFIsExpected(resp) || timeoutSecond == 0 {
+					utils.SafeLogf("Stream ended (expected EOF reached): %s\n", r.RemoteAddr)
+					return 2
+				}
+
+				utils.SafeLogf("Stream ended (unexpected EOF reached): %s\n", r.RemoteAddr)
+				returnStatus = 2
+
+				utils.SafeLogf("Retrying same stream until timeout (%d seconds) is reached...\n", timeoutSecond)
+				contextSleep(ctx)
+			case result.err != nil:
+				lastErr = time.Now()
+				utils.SafeLogf("Error reading stream: %s\n", result.err.Error())
+				returnStatus = 1
+				if timeoutSecond == 0 {
+					return 1
+				}
+
+				utils.SafeLogf("Retrying same stream until timeout (%d seconds) is reached...\n", timeoutSecond)
+				contextSleep(ctx)
+			case result.err == nil:
+				if _, err := w.Write(buffer[:result.n]); err != nil {
+					utils.SafeLogf("Error writing to response: %s\n", err.Error())
+					return 0
+				}
+
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+
+				// check if never errored or last error was at least a second ago
+				if lastErr.Equal(timeStarted) || time.Since(lastErr) >= time.Second {
+					// Reset timer on successful read/write
+					timeStarted = time.Now()
+
+					currentBackoff = initialBackoff
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* Might resolve #204
* Using VPNs will not route M3U8 streams to the VPN if accessed externally (like gluetun).

## Choices

* Change all URLs within M3U8 file to redirect to the proxy.

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.