### PR TITLE
Dockerfile and Readme Corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+my-docker-compose.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the official Golang image
-FROM golang:alpine AS build
+FROM docker.io/library/golang:alpine AS build
 
 # Set the Current Working Directory inside the container
 WORKDIR /app
@@ -18,7 +18,7 @@ RUN go test ./... && go build -ldflags='-s -w' -o m3u-proxy .
 
 # End from the latest alpine image
 # hadolint ignore=DL3007
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 # add bash and timezone data
 # hadolint ignore=DL3018

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | ENV VAR                     | Description                                              | Default Value | Possible Values                                |
 |-----------------------------|----------------------------------------------------------|---------------|------------------------------------------------|
 | BASE_URL | Sets the base URL for the stream URls in the M3U file to be generated. | http/s://<request_hostname> (e.g. <http://192.168.1.10:8080>)    | Any string that follows the URL format  |
-| SORTING_KEY | Set tag to be used for sorting the stream list | tvg-id | tvg-id, tvg-chno, tvg-group, tvg-type |
+| SORTING_KEY | Set tag to be used for sorting the stream list | title | tvg-id, tvg-chno, tvg-group, tvg-type |
 | SORTING_DIRECTION | Set sorting direction based on `SORTING_KEY` | asc | asc, desc |
 | INCLUDE_GROUPS_1, INCLUDE_GROUPS_2, INCLUDE_GROUPS_X    | Set channels to include based on groups (Takes precedence over EXCLUDE_GROUPS_X) | N/A | Go regexp |
 | EXCLUDE_GROUPS_1, EXCLUDE_GROUPS_2, EXCLUDE_GROUPS_X    | Set channels to exclude based on groups | N/A | Go regexp |


### PR DESCRIPTION
Please at least use the Dockerfile in this.  It just changes to FQDN's for the image registries.  When using Podman it is required to use valid registries, which means it needs FQDNs

Also corrected the readme for the default sort... which is by title, not tvg-id