### PR TITLE
remove inner loops in m3u line parsings + use hashes as id for subIndex with sorting

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -120,7 +120,12 @@ func TestStreamHTTPHandler(t *testing.T) {
 			}()
 
 			// Fetch original stream for comparison
-			originalURL := stream.URLs["1"]["0"]
+			firstKey := ""
+			for key := range stream.URLs["1"] {
+				firstKey = key
+				break
+			}
+			originalURL := stream.URLs["1"][firstKey]
 			t.Logf("Fetching original stream from: %s", originalURL)
 
 			res, err := utils.HTTPClient.Get(originalURL)

--- a/proxy/loadbalancer/instance.go
+++ b/proxy/loadbalancer/instance.go
@@ -228,7 +228,18 @@ func (instance *LoadBalancerInstance) tryStreamUrls(
 		return nil, fmt.Errorf("HTTP client cannot be nil")
 	}
 
-	for subIndex, url := range urls {
+	for _, subIndex := range store.SortStreamSubUrls(urls) {
+		fileContent, ok := urls[subIndex]
+		if !ok {
+			continue
+		}
+
+		url := fileContent
+		fileContentSplit := strings.SplitN(fileContent, ":::", 2)
+		if len(fileContent) == 2 {
+			url = fileContentSplit[1]
+		}
+
 		id := index + "|" + subIndex
 		session.Mutex.RLock()
 		alreadyTested := slices.Contains(session.TestedIndexes, index+"|"+subIndex)


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* M3U parsing has a lot of things going on now. This is just a PR to clean things up and flatten out nested loops as much as possible.

## Choices

* Move regex compilations to package-level to avoid unnecessary recompilations.
* Hash URLs within a M3U to serve as its ID to remove the need to loop for uniqueness
* Since `subIdx`s are now hash strings, `SortStreamSubUrls` is needed to retain order in the load balancer.

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.