### PR TITLE
remove CACHE_ON_SYNC from existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
+      - BASE_URL=http://<server>:<port> # THIS IS REQUIRED
       - TZ=America/Toronto
       - SYNC_ON_BOOT=true
       - SYNC_CRON=0 0 * * *
@@ -113,7 +114,6 @@ Access the generated M3U playlist at `http://<server ip>:8080/playlist.m3u`.
 | USER_AGENT                  | Set the User-Agent of HTTP requests.                    | IPTV Smarters/1.0.3 (iPad; iOS 16.6.1; Scale/2.00)    |  Any valid user agent        |
 | SYNC_CRON                   | Set cron schedule expression of the background updates. | 0 0 * * *   |  Any valid cron expression    |
 | SYNC_ON_BOOT                | Set if an initial background syncing will be executed on boot | true    | true/false   |
-| CACHE_ON_SYNC               | Set if an initial background cache building will be executed after sync. Requires BASE_URL to be set. | false | true/false   |
 | CLEAR_ON_BOOT                | Set if an initial database clearing will be executed on boot | false   | true/false   |
 
 ### Load Balancer Configs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,22 +9,15 @@ services:
       - TZ=America/New_York
       - CLEAR_ON_BOOT=true
       - SYNC_ON_BOOT=true
-      - CACHE_ON_SYNC=true
       - BASE_URL=http://YOUR_BASE_URL:THE_PORT/
       - SYNC_CRON=0 0 * * *
       - M3U_URL_1=YOUR_LOCAL_OR_REMOTE_M3U
       - M3U_MAX_CONCURRENCY_1=2
       - SORTING_KEY=tvg-type # tvg-group, tvg-chno, tvg-id: default is Name
       - SORTING_DIRECTION=asc # desc: default is asc
-      - PARSER_WORKERS=8
       - MAX_RETRIES=5
       - RETRY_WAIT=5
-      - BUFFER_MB=32
       - STREAM_TIMEOUT=7
-      - DEBUG=false
     ports:
       - YOUR_PORT:8080
-    network:
-      - bridge
-    tmpfs: /tmp
     restart: unless-stopped

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -87,21 +87,13 @@ func (instance *Updater) UpdateSources(ctx context.Context) {
 	default:
 		instance.logger.Log("Background process: Updating sources...")
 
-		cacheOnSync := os.Getenv("CACHE_ON_SYNC")
-		if len(strings.TrimSpace(cacheOnSync)) == 0 {
-			cacheOnSync = "false"
-		}
-
 		instance.logger.Log("Background process: Building merged M3U...")
-		if cacheOnSync == "true" {
-			instance.logger.Log("CACHE_ON_SYNC enabled. Building cache.")
-			if _, ok := os.LookupEnv("BASE_URL"); !ok {
-				instance.logger.Error("BASE_URL is required for CACHE_ON_SYNC to work.")
-				return
-			}
-			if err := processor.Run(ctx, nil); err == nil {
-				instance.m3uHandler.SetProcessedPath(processor.GetResultPath())
-			}
+		if _, ok := os.LookupEnv("BASE_URL"); !ok {
+			instance.logger.Error("BASE_URL is required for M3U processing to work.")
+			return
+		}
+		if err := processor.Run(ctx, nil); err == nil {
+			instance.m3uHandler.SetProcessedPath(processor.GetResultPath())
 		}
 	}
 }


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->

* `CACHE_ON_SYNC` is now required and should be removed as an env var option.

## Choices

* <!-- * Why did you solve it like this? -->

## Test instructions

1. <!-- 1. How did you test this PR? -->

## Checklist before requesting a review

* [ ] I have performed a self-review of my code
* [ ] I've added documentation about this change to the README.
* [ ] I've not introduced breaking changes.